### PR TITLE
fix emoji

### DIFF
--- a/src/emoji/Emoji.tsx
+++ b/src/emoji/Emoji.tsx
@@ -33,6 +33,8 @@ export function Emoji({
     className?: string;
 }) {
     const drawEmoji = useDrawEmoji();
+    if (!drawEmoji) return null;
+
     return (
         <DebugCanvas
             width={sizePx}

--- a/src/emoji/drawEmoji.tsx
+++ b/src/emoji/drawEmoji.tsx
@@ -1,7 +1,7 @@
 import { Emoji, characters } from "@/emoji/Emoji";
 import { loadImage } from "@/lib/load";
 import { lazy } from "@/lib/utils";
-import { use, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 interface Assets {
     emoji: HTMLImageElement;
@@ -26,8 +26,31 @@ export async function createDrawEmoji() {
 }
 
 export function useDrawEmoji() {
-    const assets = use(loadAssets());
-    return useMemo(() => drawEmoji.bind(null, assets), [assets]);
+    const [assets, setAssets] = useState<Assets | null>(null);
+
+    useEffect(() => {
+        let isCancelled = false;
+
+        loadAssets().then(
+            (assets) => {
+                if (isCancelled) return;
+                setAssets(assets);
+            },
+            (error) => {
+                if (isCancelled) return;
+                console.error(error);
+            },
+        );
+
+        return () => {
+            isCancelled = true;
+        };
+    }, []);
+
+    return useMemo(
+        () => (assets ? drawEmoji.bind(null, assets) : null),
+        [assets],
+    );
 }
 
 function drawEmoji(


### PR DESCRIPTION
It looks like you were using a canary build of React (18.3.0-canary-2f8f77602-20240229) then downgraded back to 18.3.1. The canary build of React has the new `use()` function but the non-canary build doesn't. Usage of the `use()` function in the `emoji` toy was causing it to throw an error whenever you tried to click "+" to open the emoji picker.

https://github.com/SomeHats/toys/commit/c4110420b2b6f7f01bdc3c0217d7010d94109473#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

I replaced `use()` with something pretty dumb promise loading code. There will technically be a loading state where emojis don't render for a bit but I didn't seem to notice any meaningful delay when I tested locally. Given I'm the one usually referring to this demo it's fine by me if I have to open the picker once to preload the assets before getting a clean open lol

I considered `throw`ing a promise but I didn't see any `<Suspense>`y stuff setup so guessed you had suspense setup then decided to bail on suspense.