### PR TITLE
Add preview deployments for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,19 +6,20 @@ on:
     push:
         branches:
             - main
+    pull_request:
+        types: [opened, synchronize, reopened]
 
-# Allow one concurrent deployment
 concurrency:
-    group: "pages"
+    group: deploy-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
-
-env:
-    VITE_BASE: "/toys/"
 
 jobs:
     build:
         runs-on: ubuntu-latest
         timeout-minutes: 30
+        env:
+            VITE_BASE:
+                ${{ github.event_name == 'pull_request' && '/' || '/toys/' }}
         steps:
             - name: Setup Node
               uses: actions/setup-node@v3
@@ -85,9 +86,10 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   path: dist/
-                  name: github-pages
+                  name: build-output
 
-    deploy:
+    deploy-pages:
+        if: github.event_name == 'push'
         environment:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}
@@ -112,7 +114,7 @@ jobs:
             - name: Download
               uses: actions/download-artifact@v4
               with:
-                  name: github-pages
+                  name: build-output
 
             - name: Commit & push changes
               run: |
@@ -123,3 +125,70 @@ jobs:
                   commit_ref="$(git commit-tree "$tree_ref" -p HEAD -p "$GITHUB_SHA" -m "[automated] publish from $GITHUB_SHA on $(date)")"
                   git update-ref refs/heads/gh-pages "$commit_ref"
                   git push
+
+    deploy-preview:
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        needs: build
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: actions/checkout@v3
+
+            - uses: actions/download-artifact@v4
+              with:
+                  name: build-output
+                  path: dist/
+
+            - name: Deploy to Cloudflare Workers
+              id: deploy
+              uses: cloudflare/wrangler-action@v3
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  command:
+                      deploy --name toys-pr-${{ github.event.pull_request.number
+                      }}
+
+            - name: Comment preview URL on PR
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const marker = '<!-- preview-deploy -->';
+                      const workerName = `toys-pr-${context.payload.pull_request.number}`;
+                      const url = `https://${workerName}.${process.env.CLOUDFLARE_ACCOUNT_ID}.workers.dev`;
+                      const deployUrl = '${{ steps.deploy.outputs.deployment-url }}';
+                      const previewUrl = deployUrl || url;
+                      const body = [
+                          marker,
+                          `**Preview deploy** is ready!`,
+                          '',
+                          `${previewUrl}`,
+                          '',
+                          `_Built from ${context.sha.slice(0, 7)}_`,
+                      ].join('\n');
+
+                      const { data: comments } = await github.rest.issues.listComments({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.payload.pull_request.number,
+                      });
+
+                      const existing = comments.find(c => c.body.includes(marker));
+                      if (existing) {
+                          await github.rest.issues.updateComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              comment_id: existing.id,
+                              body,
+                          });
+                      } else {
+                          await github.rest.issues.createComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: context.payload.pull_request.number,
+                              body,
+                          });
+                      }
+              env:
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,18 @@
+name: Cleanup preview deploy
+
+on:
+    pull_request:
+        types: [closed]
+
+jobs:
+    cleanup:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Delete preview worker
+              uses: cloudflare/wrangler-action@v3
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  command: delete --name toys-pr-${{ github.event.pull_request.number }} --force

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "toys-preview"
+compatibility_date = "2025-01-01"
+
+[assets]
+directory = "./dist"


### PR DESCRIPTION
## Summary
This PR adds preview deployment functionality for pull requests using Cloudflare Workers, while maintaining the existing production deployment pipeline for the main branch.

## Key Changes

- **Pull request trigger**: Added `pull_request` event trigger to the build workflow for opened, synchronize, and reopened events
- **Dynamic base path**: Modified `VITE_BASE` environment variable to use `/` for PR builds and `/toys/` for production builds
- **Improved concurrency**: Updated concurrency group to use PR number for pull requests and git ref for pushes, allowing parallel builds for different PRs
- **Artifact naming**: Renamed artifact from `github-pages` to `build-output` for clarity
- **Production deployment guard**: Added `if: github.event_name == 'push'` condition to the `deploy` job (renamed to `deploy-pages`) to ensure it only runs on main branch pushes
- **New preview deployment job**: Added `deploy-preview` job that:
  - Runs only on pull requests
  - Deploys built artifacts to Cloudflare Workers with PR-specific naming (`toys-pr-{PR_NUMBER}`)
  - Comments on the PR with the preview URL
  - Updates existing comments if the preview is redeployed
- **Preview cleanup workflow**: Added new `preview-cleanup.yml` workflow that automatically deletes preview workers when PRs are closed
- **Wrangler configuration**: Added `wrangler.toml` configuration file for Cloudflare Workers deployment

## Implementation Details

- Preview URLs are generated from either the Wrangler deployment output or constructed from the Cloudflare account ID
- PR comments include a marker (`<!-- preview-deploy -->`) to enable idempotent updates on subsequent deployments
- The preview deployment requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets to be configured

https://claude.ai/code/session_015vs1SrQi7gY45GQJBn23w7