### PR TITLE
Add adaptive dithering tool for screen printing

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -15,4 +15,6 @@ jobs:
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-                  command: delete --name toys-pr-${{ github.event.pull_request.number }} --force
+                  command:
+                      delete --name toys-pr-${{ github.event.pull_request.number
+                      }} --force

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,9 +196,14 @@ After completing each prompt, always run the following and fix any issues:
 
 ```sh
 yarn format           # Auto-format with Prettier
-yarn types            # TypeScript type checking
-yarn lint             # ESLint
+yarn check            # Run all checks: types + lint + test
 ```
+
+**Note:** `yarn check` runs `yarn types && yarn lint && yarn test`. The type
+check will fail with errors about `@/sim/crate/pkg/sim` and
+`@/slomojs/crate/pkg/slomojs` if the Rust/WASM crates haven't been built
+(`yarn build:rust`). These are pre-existing and can be ignored locally — CI
+builds the crates first.
 
 ## CI/CD
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "build:rust:sim": "wasm-pack build ./src/sim/crate --target web --release",
         "types": "tsc --build",
         "lint": "eslint --report-unused-disable-directives .",
-        "test": "vitest",
+        "test": "vitest run",
         "check": "yarn types && yarn lint && yarn test",
         "format": "git ls-files | grep -E '.*\\.(js|mjs|cjs|ts|jsx|tsx|html|css|json|yml|md)$' | xargs prettier --write"
     },

--- a/src/adaptive-dither/App.tsx
+++ b/src/adaptive-dither/App.tsx
@@ -35,6 +35,13 @@ const DROP_OFF_FUNCTIONS: ProcessingParams["dropOffFunction"][] = [
     "sine",
 ];
 
+const DITHER_PATTERNS: ProcessingParams["ditherPattern"][] = [
+    "floyd-steinberg",
+    "atkinson",
+    "ordered",
+    "noise",
+];
+
 export function App() {
     const [image, setImage] = useState<HTMLImageElement | null>(null);
     const [params, setParams] = useState<ProcessingParams>(DEFAULT_PARAMS);
@@ -136,6 +143,8 @@ export function App() {
                         params.maxDitherLevels,
                         params.contrastRangeLow,
                         params.contrastRangeHigh,
+                        params.ditherPattern,
+                        params.preserveBlocks,
                         {
                             signal: controller.signal,
                             onProgress: (p) => setCpuProgress(p),
@@ -354,6 +363,28 @@ export function App() {
 
                 {/* Pass 4: Adaptive Dithering */}
                 <Section title="4. Adaptive Dithering">
+                    <div className="mb-2">
+                        <label className="mb-1 block text-xs font-bold text-stone-500">
+                            Pattern
+                        </label>
+                        <div className="flex flex-wrap gap-1">
+                            {DITHER_PATTERNS.map((p) => (
+                                <button
+                                    key={p}
+                                    className={`rounded px-2 py-1 text-xs font-bold tracking-wide transition-colors ${
+                                        params.ditherPattern === p ?
+                                            "bg-stone-700 text-stone-100"
+                                        :   "bg-stone-200 text-stone-500 hover:bg-stone-300"
+                                    }`}
+                                    onClick={() =>
+                                        updateParam("ditherPattern", p)
+                                    }
+                                >
+                                    {p}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
                     <Slider
                         label="Resolution Levels"
                         value={params.maxDitherLevels}
@@ -378,6 +409,17 @@ export function App() {
                         step={0.01}
                         onChange={(v) => updateParam("contrastRangeHigh", v)}
                     />
+                    <label className="flex cursor-pointer items-center gap-2 text-xs font-bold text-stone-500">
+                        <input
+                            type="checkbox"
+                            checked={params.preserveBlocks}
+                            onChange={(e) =>
+                                updateParam("preserveBlocks", e.target.checked)
+                            }
+                            className="accent-stone-600"
+                        />
+                        Preserve Blocks
+                    </label>
                 </Section>
             </div>
         </div>

--- a/src/adaptive-dither/App.tsx
+++ b/src/adaptive-dither/App.tsx
@@ -1,15 +1,6 @@
 import { DitherPipeline } from "@/adaptive-dither/gpuPipeline";
 import type { ProcessingParams } from "@/adaptive-dither/processing";
-import {
-    adaptiveDither,
-    applyBrightnessContrast,
-    buildContrastMap,
-    DEFAULT_PARAMS,
-    detectEdges,
-    getScaledGrayscale,
-    renderBinary,
-    renderGrayscale,
-} from "@/adaptive-dither/processing";
+import { DEFAULT_PARAMS } from "@/adaptive-dither/processing";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 type PassName =
@@ -41,7 +32,6 @@ export function App() {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const pipelineRef = useRef<DitherPipeline | null>(null);
-    const gpuFailedRef = useRef(false);
 
     const scaledWidth =
         image ? Math.round(image.naturalWidth * params.scale) : 0;
@@ -78,63 +68,13 @@ export function App() {
         if (!canvas || !image || scaledWidth === 0 || scaledHeight === 0)
             return;
 
-        // Try GPU pipeline, fall back to CPU on any error
-        if (!gpuFailedRef.current) {
-            try {
-                pipelineRef.current ??= new DitherPipeline(canvas);
-                const pipeline = pipelineRef.current;
-                pipeline.uploadImage(image, scaledWidth, scaledHeight);
-                pipeline.runPipeline(params);
-                pipeline.displayPass(activePass);
-                return;
-            } catch (e) {
-                console.error("GPU pipeline failed, falling back to CPU:", e);
-                gpuFailedRef.current = true;
-                pipelineRef.current?.destroy();
-                pipelineRef.current = null;
-            }
-        }
+        // Lazily create the pipeline on first use
+        pipelineRef.current ??= new DitherPipeline(canvas);
+        const pipeline = pipelineRef.current;
 
-        // CPU fallback
-        const w = scaledWidth;
-        const h = scaledHeight;
-        const grayscale = getScaledGrayscale(image, w, h);
-        const preprocessed = applyBrightnessContrast(
-            grayscale,
-            params.brightness,
-            params.contrast,
-        );
-        const edges = detectEdges(preprocessed, w, h, params.edgeStrength);
-        const contrastMap = buildContrastMap(
-            edges,
-            w,
-            h,
-            params.dropOffRate,
-            params.dropOffFunction,
-        );
-        const dithered = adaptiveDither(
-            preprocessed,
-            contrastMap,
-            w,
-            h,
-            params.maxDitherLevels,
-            params.contrastRangeLow,
-            params.contrastRangeHigh,
-        );
-
-        const data: Record<string, Float32Array | Uint8Array> = {
-            original: grayscale,
-            preprocessed,
-            edges,
-            contrastMap,
-            dithered,
-        };
-        const d = data[activePass];
-        if (d instanceof Uint8Array) {
-            renderBinary(d, w, h, canvas);
-        } else {
-            renderGrayscale(d, w, h, canvas);
-        }
+        pipeline.uploadImage(image, scaledWidth, scaledHeight);
+        pipeline.runPipeline(params);
+        pipeline.displayPass(activePass);
     }, [image, scaledWidth, scaledHeight, params, activePass]);
 
     // Clean up pipeline on unmount

--- a/src/adaptive-dither/App.tsx
+++ b/src/adaptive-dither/App.tsx
@@ -69,9 +69,7 @@ export function App() {
             return;
 
         // Lazily create the pipeline on first use
-        if (!pipelineRef.current) {
-            pipelineRef.current = new DitherPipeline(canvas);
-        }
+        pipelineRef.current ??= new DitherPipeline(canvas);
         const pipeline = pipelineRef.current;
 
         pipeline.uploadImage(image, scaledWidth, scaledHeight);

--- a/src/adaptive-dither/App.tsx
+++ b/src/adaptive-dither/App.tsx
@@ -62,34 +62,36 @@ export function App() {
         [],
     );
 
-    // Initialize pipeline when canvas is available
-    useEffect(() => {
-        const canvas = canvasRef.current;
-        if (!canvas) return;
-        const pipeline = new DitherPipeline(canvas);
-        pipelineRef.current = pipeline;
-        return () => {
-            pipeline.destroy();
-            pipelineRef.current = null;
-        };
-    }, []);
-
     // Run pipeline when image or params change
     useEffect(() => {
-        const pipeline = pipelineRef.current;
-        if (!pipeline || !image || scaledWidth === 0 || scaledHeight === 0)
+        const canvas = canvasRef.current;
+        if (!canvas || !image || scaledWidth === 0 || scaledHeight === 0)
             return;
+
+        // Lazily create the pipeline on first use
+        if (!pipelineRef.current) {
+            pipelineRef.current = new DitherPipeline(canvas);
+        }
+        const pipeline = pipelineRef.current;
 
         pipeline.uploadImage(image, scaledWidth, scaledHeight);
         pipeline.runPipeline(params);
         pipeline.displayPass(activePass);
     }, [image, scaledWidth, scaledHeight, params, activePass]);
 
+    // Clean up pipeline on unmount
+    useEffect(() => {
+        return () => {
+            pipelineRef.current?.destroy();
+            pipelineRef.current = null;
+        };
+    }, []);
+
     return (
         <div className="flex h-full">
             {/* Left: Canvas / Image Preview */}
             <div className="flex flex-1 flex-col items-center justify-center bg-stone-200 p-4">
-                {!image ?
+                {!image && (
                     <div className="flex flex-col items-center gap-4">
                         <p className="text-lg text-stone-500">
                             Upload an image to get started
@@ -101,21 +103,22 @@ export function App() {
                             Choose Image
                         </button>
                     </div>
-                :   <div className="flex flex-col items-center gap-2">
-                        <canvas
-                            ref={canvasRef}
-                            className="max-h-[80vh] max-w-full border border-stone-300"
-                            style={{
-                                imageRendering: "pixelated",
-                            }}
-                        />
-                        <p className="text-xs text-stone-400">
-                            {scaledWidth} x {scaledHeight}px — GPU accelerated
-                        </p>
-                    </div>
-                }
-                {/* Hidden canvas for WebGL when no image yet */}
-                {!image && <canvas ref={canvasRef} className="hidden" />}
+                )}
+                {/* Always render the canvas so the WebGL context persists */}
+                <div
+                    className={
+                        image ? "flex flex-col items-center gap-2" : "hidden"
+                    }
+                >
+                    <canvas
+                        ref={canvasRef}
+                        className="max-h-[80vh] max-w-full border border-stone-300"
+                        style={{ imageRendering: "pixelated" }}
+                    />
+                    <p className="text-xs text-stone-400">
+                        {scaledWidth} x {scaledHeight}px — GPU accelerated
+                    </p>
+                </div>
                 <input
                     ref={fileInputRef}
                     type="file"

--- a/src/adaptive-dither/App.tsx
+++ b/src/adaptive-dither/App.tsx
@@ -3,7 +3,6 @@ import type { ProcessingParams } from "@/adaptive-dither/processing";
 import {
     DEFAULT_PARAMS,
     adaptiveDitherAsync,
-    buildContrastMapAsync,
 } from "@/adaptive-dither/processing";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -22,7 +21,12 @@ const PASS_LABELS: Record<PassName, string> = {
     dithered: "4. Adaptive Dither",
 };
 
-const GPU_PASSES = new Set<PassName>(["original", "preprocessed", "edges"]);
+const GPU_PASSES = new Set<PassName>([
+    "original",
+    "preprocessed",
+    "edges",
+    "contrastMap",
+]);
 
 const DROP_OFF_FUNCTIONS: ProcessingParams["dropOffFunction"][] = [
     "linear",
@@ -75,13 +79,12 @@ export function App() {
         [updateParam],
     );
 
-    // Run GPU passes immediately, schedule CPU passes with debounce
+    // Run GPU passes immediately, schedule CPU dither with debounce
     useEffect(() => {
         const canvas = canvasRef.current;
         if (!canvas || !image || scaledWidth === 0 || scaledHeight === 0)
             return;
 
-        // Lazily create the pipeline on first use
         pipelineRef.current ??= new DitherPipeline(canvas);
         const pipeline = pipelineRef.current;
 
@@ -103,7 +106,7 @@ export function App() {
             clearTimeout(debounceRef.current);
         }
 
-        // Schedule CPU passes after debounce
+        // Schedule CPU dither pass after debounce
         debounceRef.current = setTimeout(() => {
             debounceRef.current = null;
             const controller = new AbortController();
@@ -116,36 +119,15 @@ export function App() {
                 try {
                     setCpuProgress(0);
 
-                    // Read GPU results
+                    // Read GPU results for CPU dithering
                     const preprocessed = pipeline.readPassPixels(
                         DitherPipeline.PASS_PREPROCESSED,
                     );
-                    const edges = pipeline.readPassPixels(
-                        DitherPipeline.PASS_EDGES,
-                    );
-
-                    // Pass 3: Contrast map
-                    const contrastMap = await buildContrastMapAsync(
-                        edges,
-                        w,
-                        h,
-                        params.dropOffRate,
-                        params.dropOffFunction,
-                        {
-                            signal: controller.signal,
-                            onProgress: (p) => setCpuProgress(p * 0.5),
-                        },
-                    );
-
-                    pipeline.uploadGrayscaleToPass(
+                    const contrastMap = pipeline.readPassPixels(
                         DitherPipeline.PASS_CONTRAST_MAP,
-                        contrastMap,
                     );
-                    if (activePass === "contrastMap") {
-                        pipeline.displayPass("contrastMap");
-                    }
 
-                    // Pass 4: Adaptive dither
+                    // Pass 4: Adaptive dither (CPU)
                     const dithered = await adaptiveDitherAsync(
                         preprocessed,
                         contrastMap,
@@ -156,7 +138,7 @@ export function App() {
                         params.contrastRangeHigh,
                         {
                             signal: controller.signal,
-                            onProgress: (p) => setCpuProgress(0.5 + p * 0.5),
+                            onProgress: (p) => setCpuProgress(p),
                         },
                     );
 
@@ -339,12 +321,12 @@ export function App() {
                 {/* Pass 3: Contrast Map */}
                 <Section title="3. Contrast Map">
                     <Slider
-                        label="Drop-off Rate"
-                        value={params.dropOffRate}
-                        min={0.001}
-                        max={0.3}
-                        step={0.001}
-                        onChange={(v) => updateParam("dropOffRate", v)}
+                        label="Radius"
+                        value={params.radius}
+                        min={1}
+                        max={200}
+                        step={1}
+                        onChange={(v) => updateParam("radius", v)}
                     />
                     <div className="mb-2">
                         <label className="mb-1 block text-xs font-bold text-stone-500">

--- a/src/adaptive-dither/App.tsx
+++ b/src/adaptive-dither/App.tsx
@@ -1,6 +1,10 @@
 import { DitherPipeline } from "@/adaptive-dither/gpuPipeline";
 import type { ProcessingParams } from "@/adaptive-dither/processing";
-import { DEFAULT_PARAMS } from "@/adaptive-dither/processing";
+import {
+    DEFAULT_PARAMS,
+    adaptiveDitherAsync,
+    buildContrastMapAsync,
+} from "@/adaptive-dither/processing";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 type PassName =
@@ -18,6 +22,8 @@ const PASS_LABELS: Record<PassName, string> = {
     dithered: "4. Adaptive Dither",
 };
 
+const GPU_PASSES = new Set<PassName>(["original", "preprocessed", "edges"]);
+
 const DROP_OFF_FUNCTIONS: ProcessingParams["dropOffFunction"][] = [
     "linear",
     "exponential",
@@ -29,9 +35,12 @@ export function App() {
     const [image, setImage] = useState<HTMLImageElement | null>(null);
     const [params, setParams] = useState<ProcessingParams>(DEFAULT_PARAMS);
     const [activePass, setActivePass] = useState<PassName>("dithered");
+    const [cpuProgress, setCpuProgress] = useState<number | null>(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const pipelineRef = useRef<DitherPipeline | null>(null);
+    const abortRef = useRef<AbortController | null>(null);
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const scaledWidth =
         image ? Math.round(image.naturalWidth * params.scale) : 0;
@@ -54,15 +63,19 @@ export function App() {
             if (!file) return;
             const img = new Image();
             img.onload = () => {
+                const maxDim = Math.max(img.naturalWidth, img.naturalHeight);
+                if (maxDim > 1000) {
+                    updateParam("scale", 1000 / maxDim);
+                }
                 setImage(img);
                 URL.revokeObjectURL(img.src);
             };
             img.src = URL.createObjectURL(file);
         },
-        [],
+        [updateParam],
     );
 
-    // Run pipeline when image or params change
+    // Run GPU passes immediately, schedule CPU passes with debounce
     useEffect(() => {
         const canvas = canvasRef.current;
         if (!canvas || !image || scaledWidth === 0 || scaledHeight === 0)
@@ -73,8 +86,109 @@ export function App() {
         const pipeline = pipelineRef.current;
 
         pipeline.uploadImage(image, scaledWidth, scaledHeight);
-        pipeline.runPipeline(params);
-        pipeline.displayPass(activePass);
+        pipeline.runGpuPasses(params);
+
+        // Display GPU pass immediately if viewing one
+        if (GPU_PASSES.has(activePass)) {
+            pipeline.displayPass(activePass);
+        }
+
+        // Cancel any in-progress CPU work
+        abortRef.current?.abort();
+        abortRef.current = null;
+        setCpuProgress(null);
+
+        // Clear pending debounce
+        if (debounceRef.current !== null) {
+            clearTimeout(debounceRef.current);
+        }
+
+        // Schedule CPU passes after debounce
+        debounceRef.current = setTimeout(() => {
+            debounceRef.current = null;
+            const controller = new AbortController();
+            abortRef.current = controller;
+
+            const runCpu = async () => {
+                const w = pipeline.width;
+                const h = pipeline.height;
+
+                try {
+                    setCpuProgress(0);
+
+                    // Read GPU results
+                    const preprocessed = pipeline.readPassPixels(
+                        DitherPipeline.PASS_PREPROCESSED,
+                    );
+                    const edges = pipeline.readPassPixels(
+                        DitherPipeline.PASS_EDGES,
+                    );
+
+                    // Pass 3: Contrast map
+                    const contrastMap = await buildContrastMapAsync(
+                        edges,
+                        w,
+                        h,
+                        params.dropOffRate,
+                        params.dropOffFunction,
+                        {
+                            signal: controller.signal,
+                            onProgress: (p) => setCpuProgress(p * 0.5),
+                        },
+                    );
+
+                    pipeline.uploadGrayscaleToPass(
+                        DitherPipeline.PASS_CONTRAST_MAP,
+                        contrastMap,
+                    );
+                    if (activePass === "contrastMap") {
+                        pipeline.displayPass("contrastMap");
+                    }
+
+                    // Pass 4: Adaptive dither
+                    const dithered = await adaptiveDitherAsync(
+                        preprocessed,
+                        contrastMap,
+                        w,
+                        h,
+                        params.maxDitherLevels,
+                        params.contrastRangeLow,
+                        params.contrastRangeHigh,
+                        {
+                            signal: controller.signal,
+                            onProgress: (p) => setCpuProgress(0.5 + p * 0.5),
+                        },
+                    );
+
+                    pipeline.uploadBinaryToPass(
+                        DitherPipeline.PASS_DITHERED,
+                        dithered,
+                    );
+                    if (activePass === "dithered") {
+                        pipeline.displayPass("dithered");
+                    }
+
+                    setCpuProgress(null);
+                } catch (e) {
+                    if (e instanceof DOMException && e.name === "AbortError") {
+                        setCpuProgress(null);
+                    } else {
+                        throw e;
+                    }
+                }
+            };
+
+            void runCpu();
+        }, 150);
+
+        return () => {
+            abortRef.current?.abort();
+            abortRef.current = null;
+            if (debounceRef.current !== null) {
+                clearTimeout(debounceRef.current);
+                debounceRef.current = null;
+            }
+        };
     }, [image, scaledWidth, scaledHeight, params, activePass]);
 
     // Clean up pipeline on unmount
@@ -88,7 +202,7 @@ export function App() {
     return (
         <div className="flex h-full">
             {/* Left: Canvas / Image Preview */}
-            <div className="flex flex-1 flex-col items-center justify-center bg-stone-200 p-4">
+            <div className="flex min-h-0 flex-1 flex-col items-center justify-center overflow-hidden bg-stone-200 p-4">
                 {!image && (
                     <div className="flex flex-col items-center gap-4">
                         <p className="text-lg text-stone-500">
@@ -105,16 +219,31 @@ export function App() {
                 {/* Always render the canvas so the WebGL context persists */}
                 <div
                     className={
-                        image ? "flex flex-col items-center gap-2" : "hidden"
+                        image ?
+                            "relative flex min-h-0 flex-1 flex-col items-center justify-center gap-2"
+                        :   "hidden"
                     }
                 >
                     <canvas
                         ref={canvasRef}
-                        className="max-h-[80vh] max-w-full border border-stone-300"
+                        className="max-h-full max-w-full border border-stone-300"
                         style={{ imageRendering: "pixelated" }}
                     />
-                    <p className="text-xs text-stone-400">
-                        {scaledWidth} x {scaledHeight}px — GPU accelerated
+                    {cpuProgress !== null && (
+                        <div className="absolute bottom-8 left-0 right-0 mx-auto h-1 w-3/4 overflow-hidden rounded-full bg-stone-300">
+                            <div
+                                className="h-full bg-stone-600 transition-[width] duration-100"
+                                style={{
+                                    width: `${Math.round(cpuProgress * 100)}%`,
+                                }}
+                            />
+                        </div>
+                    )}
+                    <p className="shrink-0 text-xs text-stone-400">
+                        {scaledWidth} x {scaledHeight}px
+                        {cpuProgress !== null ?
+                            " — Processing..."
+                        :   " — GPU + CPU hybrid"}
                     </p>
                 </div>
                 <input

--- a/src/adaptive-dither/App.tsx
+++ b/src/adaptive-dither/App.tsx
@@ -1,0 +1,408 @@
+import {
+    DEFAULT_PARAMS,
+    adaptiveDither,
+    applyBrightnessContrast,
+    buildContrastMap,
+    detectEdges,
+    getScaledGrayscale,
+    renderBinary,
+    renderGrayscale,
+} from "@/adaptive-dither/processing";
+import type { ProcessingParams } from "@/adaptive-dither/processing";
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+
+type PassName =
+    | "original"
+    | "preprocessed"
+    | "edges"
+    | "contrastMap"
+    | "dithered";
+
+const PASS_LABELS: Record<PassName, string> = {
+    original: "Original",
+    preprocessed: "1. Preprocessed",
+    edges: "2. Edge Detection",
+    contrastMap: "3. Contrast Map",
+    dithered: "4. Adaptive Dither",
+};
+
+const DROP_OFF_FUNCTIONS: ProcessingParams["dropOffFunction"][] = [
+    "linear",
+    "exponential",
+    "quadratic",
+    "sine",
+];
+
+export function App() {
+    const [image, setImage] = useState<HTMLImageElement | null>(null);
+    const [params, setParams] = useState<ProcessingParams>(DEFAULT_PARAMS);
+    const [activePass, setActivePass] = useState<PassName>("dithered");
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const scaledWidth = image ? Math.round(image.naturalWidth * params.scale) : 0;
+    const scaledHeight = image ? Math.round(image.naturalHeight * params.scale) : 0;
+
+    const updateParam = useCallback(
+        <K extends keyof ProcessingParams>(
+            key: K,
+            value: ProcessingParams[K],
+        ) => {
+            setParams((prev) => ({ ...prev, [key]: value }));
+        },
+        [],
+    );
+
+    const handleFileUpload = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+            const img = new Image();
+            img.onload = () => {
+                setImage(img);
+                URL.revokeObjectURL(img.src);
+            };
+            img.src = URL.createObjectURL(file);
+        },
+        [],
+    );
+
+    // Compute all passes
+    const passes = useMemo(() => {
+        if (!image || scaledWidth === 0 || scaledHeight === 0) return null;
+
+        const grayscale = getScaledGrayscale(
+            image,
+            scaledWidth,
+            scaledHeight,
+        );
+        const preprocessed = applyBrightnessContrast(
+            grayscale,
+            params.brightness,
+            params.contrast,
+        );
+        const edges = detectEdges(
+            preprocessed,
+            scaledWidth,
+            scaledHeight,
+            params.edgeStrength,
+        );
+        const contrastMap = buildContrastMap(
+            edges,
+            scaledWidth,
+            scaledHeight,
+            params.dropOffRate,
+            params.dropOffFunction,
+        );
+        const dithered = adaptiveDither(
+            preprocessed,
+            contrastMap,
+            scaledWidth,
+            scaledHeight,
+            params.maxDitherLevels,
+            params.contrastRangeLow,
+            params.contrastRangeHigh,
+        );
+
+        return { grayscale, preprocessed, edges, contrastMap, dithered };
+    }, [image, scaledWidth, scaledHeight, params]);
+
+    // Render active pass to canvas
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas || !passes) return;
+
+        switch (activePass) {
+            case "original":
+                renderGrayscale(
+                    passes.grayscale,
+                    scaledWidth,
+                    scaledHeight,
+                    canvas,
+                );
+                break;
+            case "preprocessed":
+                renderGrayscale(
+                    passes.preprocessed,
+                    scaledWidth,
+                    scaledHeight,
+                    canvas,
+                );
+                break;
+            case "edges":
+                renderGrayscale(
+                    passes.edges,
+                    scaledWidth,
+                    scaledHeight,
+                    canvas,
+                );
+                break;
+            case "contrastMap":
+                renderGrayscale(
+                    passes.contrastMap,
+                    scaledWidth,
+                    scaledHeight,
+                    canvas,
+                );
+                break;
+            case "dithered":
+                renderBinary(
+                    passes.dithered,
+                    scaledWidth,
+                    scaledHeight,
+                    canvas,
+                );
+                break;
+        }
+    }, [passes, activePass, scaledWidth, scaledHeight]);
+
+    return (
+        <div className="flex h-full">
+            {/* Left: Canvas / Image Preview */}
+            <div className="flex flex-1 flex-col items-center justify-center bg-stone-200 p-4">
+                {!image ?
+                    <div className="flex flex-col items-center gap-4">
+                        <p className="text-lg text-stone-500">
+                            Upload an image to get started
+                        </p>
+                        <button
+                            className="rounded bg-stone-700 px-5 py-3 font-bold tracking-wide text-stone-100 transition-transform ease-out-back hover:scale-110 active:scale-95"
+                            onClick={() => fileInputRef.current?.click()}
+                        >
+                            Choose Image
+                        </button>
+                    </div>
+                :   <div className="flex flex-col items-center gap-2">
+                        <canvas
+                            ref={canvasRef}
+                            className="max-h-[80vh] max-w-full border border-stone-300"
+                            style={{
+                                imageRendering: "pixelated",
+                            }}
+                        />
+                        <p className="text-xs text-stone-400">
+                            {scaledWidth} x {scaledHeight}px
+                        </p>
+                    </div>
+                }
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleFileUpload}
+                />
+            </div>
+
+            {/* Right: Controls Panel */}
+            <div className="flex w-80 shrink-0 flex-col overflow-y-auto border-l border-stone-300 bg-stone-50 p-4">
+                <h1 className="mb-4 text-lg font-bold tracking-wide">
+                    Adaptive Dither
+                </h1>
+
+                {image && (
+                    <button
+                        className="mb-4 rounded bg-stone-200 px-3 py-1.5 text-sm font-bold tracking-wide text-stone-600 transition-transform ease-out-back hover:scale-105 active:scale-95"
+                        onClick={() => fileInputRef.current?.click()}
+                    >
+                        Change Image
+                    </button>
+                )}
+
+                {/* Pass Selector */}
+                <Section title="View Pass">
+                    <div className="flex flex-wrap gap-1">
+                        {(Object.keys(PASS_LABELS) as PassName[]).map(
+                            (pass) => (
+                                <button
+                                    key={pass}
+                                    className={`rounded px-2 py-1 text-xs font-bold tracking-wide transition-colors ${
+                                        activePass === pass
+                                            ? "bg-stone-700 text-stone-100"
+                                            : "bg-stone-200 text-stone-500 hover:bg-stone-300"
+                                    }`}
+                                    onClick={() => setActivePass(pass)}
+                                >
+                                    {PASS_LABELS[pass]}
+                                </button>
+                            ),
+                        )}
+                    </div>
+                </Section>
+
+                {/* Pass 1: Preprocessing */}
+                <Section title="1. Preprocessing">
+                    <Slider
+                        label="Scale"
+                        value={params.scale}
+                        min={0.05}
+                        max={2}
+                        step={0.05}
+                        onChange={(v) => updateParam("scale", v)}
+                        suffix={
+                            image ?
+                                ` (${scaledWidth}x${scaledHeight})`
+                            :   undefined
+                        }
+                    />
+                    <Slider
+                        label="Brightness"
+                        value={params.brightness}
+                        min={-1}
+                        max={1}
+                        step={0.01}
+                        onChange={(v) => updateParam("brightness", v)}
+                    />
+                    <Slider
+                        label="Contrast"
+                        value={params.contrast}
+                        min={-1}
+                        max={1}
+                        step={0.01}
+                        onChange={(v) => updateParam("contrast", v)}
+                    />
+                </Section>
+
+                {/* Pass 2: Edge Detection */}
+                <Section title="2. Edge Detection">
+                    <Slider
+                        label="Edge Strength"
+                        value={params.edgeStrength}
+                        min={0.1}
+                        max={5}
+                        step={0.1}
+                        onChange={(v) => updateParam("edgeStrength", v)}
+                    />
+                </Section>
+
+                {/* Pass 3: Contrast Map */}
+                <Section title="3. Contrast Map">
+                    <Slider
+                        label="Drop-off Rate"
+                        value={params.dropOffRate}
+                        min={0.001}
+                        max={0.3}
+                        step={0.001}
+                        onChange={(v) => updateParam("dropOffRate", v)}
+                    />
+                    <div className="mb-2">
+                        <label className="mb-1 block text-xs font-bold text-stone-500">
+                            Drop-off Function
+                        </label>
+                        <div className="flex gap-1">
+                            {DROP_OFF_FUNCTIONS.map((fn) => (
+                                <button
+                                    key={fn}
+                                    className={`rounded px-2 py-1 text-xs font-bold tracking-wide transition-colors ${
+                                        params.dropOffFunction === fn
+                                            ? "bg-stone-700 text-stone-100"
+                                            : "bg-stone-200 text-stone-500 hover:bg-stone-300"
+                                    }`}
+                                    onClick={() =>
+                                        updateParam("dropOffFunction", fn)
+                                    }
+                                >
+                                    {fn}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                </Section>
+
+                {/* Pass 4: Adaptive Dithering */}
+                <Section title="4. Adaptive Dithering">
+                    <Slider
+                        label="Resolution Levels"
+                        value={params.maxDitherLevels}
+                        min={1}
+                        max={7}
+                        step={1}
+                        onChange={(v) => updateParam("maxDitherLevels", v)}
+                    />
+                    <Slider
+                        label="Contrast Range Low"
+                        value={params.contrastRangeLow}
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        onChange={(v) => updateParam("contrastRangeLow", v)}
+                    />
+                    <Slider
+                        label="Contrast Range High"
+                        value={params.contrastRangeHigh}
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        onChange={(v) => updateParam("contrastRangeHigh", v)}
+                    />
+                </Section>
+            </div>
+        </div>
+    );
+}
+
+function Section({
+    title,
+    children,
+}: {
+    title: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <div className="mb-4 border-b border-stone-200 pb-4">
+            <h2 className="mb-2 text-sm font-bold tracking-wide text-stone-600">
+                {title}
+            </h2>
+            {children}
+        </div>
+    );
+}
+
+function Slider({
+    label,
+    value,
+    min,
+    max,
+    step,
+    onChange,
+    suffix,
+}: {
+    label: string;
+    value: number;
+    min: number;
+    max: number;
+    step: number;
+    onChange: (value: number) => void;
+    suffix?: string;
+}) {
+    return (
+        <div className="mb-2">
+            <div className="mb-0.5 flex items-baseline justify-between">
+                <label className="text-xs font-bold text-stone-500">
+                    {label}
+                </label>
+                <span className="text-xs text-stone-400">
+                    {Number.isInteger(step) ?
+                        value
+                    :   value.toFixed(step < 0.01 ? 3 : 2)}
+                    {suffix}
+                </span>
+            </div>
+            <input
+                type="range"
+                min={min}
+                max={max}
+                step={step}
+                value={value}
+                onChange={(e) => onChange(parseFloat(e.target.value))}
+                className="w-full accent-stone-600"
+            />
+        </div>
+    );
+}

--- a/src/adaptive-dither/App.tsx
+++ b/src/adaptive-dither/App.tsx
@@ -1,6 +1,15 @@
 import { DitherPipeline } from "@/adaptive-dither/gpuPipeline";
 import type { ProcessingParams } from "@/adaptive-dither/processing";
-import { DEFAULT_PARAMS } from "@/adaptive-dither/processing";
+import {
+    adaptiveDither,
+    applyBrightnessContrast,
+    buildContrastMap,
+    DEFAULT_PARAMS,
+    detectEdges,
+    getScaledGrayscale,
+    renderBinary,
+    renderGrayscale,
+} from "@/adaptive-dither/processing";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 type PassName =
@@ -32,6 +41,7 @@ export function App() {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const pipelineRef = useRef<DitherPipeline | null>(null);
+    const gpuFailedRef = useRef(false);
 
     const scaledWidth =
         image ? Math.round(image.naturalWidth * params.scale) : 0;
@@ -68,13 +78,63 @@ export function App() {
         if (!canvas || !image || scaledWidth === 0 || scaledHeight === 0)
             return;
 
-        // Lazily create the pipeline on first use
-        pipelineRef.current ??= new DitherPipeline(canvas);
-        const pipeline = pipelineRef.current;
+        // Try GPU pipeline, fall back to CPU on any error
+        if (!gpuFailedRef.current) {
+            try {
+                pipelineRef.current ??= new DitherPipeline(canvas);
+                const pipeline = pipelineRef.current;
+                pipeline.uploadImage(image, scaledWidth, scaledHeight);
+                pipeline.runPipeline(params);
+                pipeline.displayPass(activePass);
+                return;
+            } catch (e) {
+                console.error("GPU pipeline failed, falling back to CPU:", e);
+                gpuFailedRef.current = true;
+                pipelineRef.current?.destroy();
+                pipelineRef.current = null;
+            }
+        }
 
-        pipeline.uploadImage(image, scaledWidth, scaledHeight);
-        pipeline.runPipeline(params);
-        pipeline.displayPass(activePass);
+        // CPU fallback
+        const w = scaledWidth;
+        const h = scaledHeight;
+        const grayscale = getScaledGrayscale(image, w, h);
+        const preprocessed = applyBrightnessContrast(
+            grayscale,
+            params.brightness,
+            params.contrast,
+        );
+        const edges = detectEdges(preprocessed, w, h, params.edgeStrength);
+        const contrastMap = buildContrastMap(
+            edges,
+            w,
+            h,
+            params.dropOffRate,
+            params.dropOffFunction,
+        );
+        const dithered = adaptiveDither(
+            preprocessed,
+            contrastMap,
+            w,
+            h,
+            params.maxDitherLevels,
+            params.contrastRangeLow,
+            params.contrastRangeHigh,
+        );
+
+        const data: Record<string, Float32Array | Uint8Array> = {
+            original: grayscale,
+            preprocessed,
+            edges,
+            contrastMap,
+            dithered,
+        };
+        const d = data[activePass];
+        if (d instanceof Uint8Array) {
+            renderBinary(d, w, h, canvas);
+        } else {
+            renderGrayscale(d, w, h, canvas);
+        }
     }, [image, scaledWidth, scaledHeight, params, activePass]);
 
     // Clean up pipeline on unmount

--- a/src/adaptive-dither/App.tsx
+++ b/src/adaptive-dither/App.tsx
@@ -1,21 +1,7 @@
-import {
-    DEFAULT_PARAMS,
-    adaptiveDither,
-    applyBrightnessContrast,
-    buildContrastMap,
-    detectEdges,
-    getScaledGrayscale,
-    renderBinary,
-    renderGrayscale,
-} from "@/adaptive-dither/processing";
+import { DitherPipeline } from "@/adaptive-dither/gpuPipeline";
 import type { ProcessingParams } from "@/adaptive-dither/processing";
-import {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from "react";
+import { DEFAULT_PARAMS } from "@/adaptive-dither/processing";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 type PassName =
     | "original"
@@ -45,9 +31,12 @@ export function App() {
     const [activePass, setActivePass] = useState<PassName>("dithered");
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const pipelineRef = useRef<DitherPipeline | null>(null);
 
-    const scaledWidth = image ? Math.round(image.naturalWidth * params.scale) : 0;
-    const scaledHeight = image ? Math.round(image.naturalHeight * params.scale) : 0;
+    const scaledWidth =
+        image ? Math.round(image.naturalWidth * params.scale) : 0;
+    const scaledHeight =
+        image ? Math.round(image.naturalHeight * params.scale) : 0;
 
     const updateParam = useCallback(
         <K extends keyof ProcessingParams>(
@@ -73,94 +62,28 @@ export function App() {
         [],
     );
 
-    // Compute all passes
-    const passes = useMemo(() => {
-        if (!image || scaledWidth === 0 || scaledHeight === 0) return null;
-
-        const grayscale = getScaledGrayscale(
-            image,
-            scaledWidth,
-            scaledHeight,
-        );
-        const preprocessed = applyBrightnessContrast(
-            grayscale,
-            params.brightness,
-            params.contrast,
-        );
-        const edges = detectEdges(
-            preprocessed,
-            scaledWidth,
-            scaledHeight,
-            params.edgeStrength,
-        );
-        const contrastMap = buildContrastMap(
-            edges,
-            scaledWidth,
-            scaledHeight,
-            params.dropOffRate,
-            params.dropOffFunction,
-        );
-        const dithered = adaptiveDither(
-            preprocessed,
-            contrastMap,
-            scaledWidth,
-            scaledHeight,
-            params.maxDitherLevels,
-            params.contrastRangeLow,
-            params.contrastRangeHigh,
-        );
-
-        return { grayscale, preprocessed, edges, contrastMap, dithered };
-    }, [image, scaledWidth, scaledHeight, params]);
-
-    // Render active pass to canvas
+    // Initialize pipeline when canvas is available
     useEffect(() => {
         const canvas = canvasRef.current;
-        if (!canvas || !passes) return;
+        if (!canvas) return;
+        const pipeline = new DitherPipeline(canvas);
+        pipelineRef.current = pipeline;
+        return () => {
+            pipeline.destroy();
+            pipelineRef.current = null;
+        };
+    }, []);
 
-        switch (activePass) {
-            case "original":
-                renderGrayscale(
-                    passes.grayscale,
-                    scaledWidth,
-                    scaledHeight,
-                    canvas,
-                );
-                break;
-            case "preprocessed":
-                renderGrayscale(
-                    passes.preprocessed,
-                    scaledWidth,
-                    scaledHeight,
-                    canvas,
-                );
-                break;
-            case "edges":
-                renderGrayscale(
-                    passes.edges,
-                    scaledWidth,
-                    scaledHeight,
-                    canvas,
-                );
-                break;
-            case "contrastMap":
-                renderGrayscale(
-                    passes.contrastMap,
-                    scaledWidth,
-                    scaledHeight,
-                    canvas,
-                );
-                break;
-            case "dithered":
-                renderBinary(
-                    passes.dithered,
-                    scaledWidth,
-                    scaledHeight,
-                    canvas,
-                );
-                break;
-        }
-    }, [passes, activePass, scaledWidth, scaledHeight]);
+    // Run pipeline when image or params change
+    useEffect(() => {
+        const pipeline = pipelineRef.current;
+        if (!pipeline || !image || scaledWidth === 0 || scaledHeight === 0)
+            return;
+
+        pipeline.uploadImage(image, scaledWidth, scaledHeight);
+        pipeline.runPipeline(params);
+        pipeline.displayPass(activePass);
+    }, [image, scaledWidth, scaledHeight, params, activePass]);
 
     return (
         <div className="flex h-full">
@@ -187,10 +110,12 @@ export function App() {
                             }}
                         />
                         <p className="text-xs text-stone-400">
-                            {scaledWidth} x {scaledHeight}px
+                            {scaledWidth} x {scaledHeight}px — GPU accelerated
                         </p>
                     </div>
                 }
+                {/* Hidden canvas for WebGL when no image yet */}
+                {!image && <canvas ref={canvasRef} className="hidden" />}
                 <input
                     ref={fileInputRef}
                     type="file"
@@ -223,9 +148,9 @@ export function App() {
                                 <button
                                     key={pass}
                                     className={`rounded px-2 py-1 text-xs font-bold tracking-wide transition-colors ${
-                                        activePass === pass
-                                            ? "bg-stone-700 text-stone-100"
-                                            : "bg-stone-200 text-stone-500 hover:bg-stone-300"
+                                        activePass === pass ?
+                                            "bg-stone-700 text-stone-100"
+                                        :   "bg-stone-200 text-stone-500 hover:bg-stone-300"
                                     }`}
                                     onClick={() => setActivePass(pass)}
                                 >
@@ -300,9 +225,9 @@ export function App() {
                                 <button
                                     key={fn}
                                     className={`rounded px-2 py-1 text-xs font-bold tracking-wide transition-colors ${
-                                        params.dropOffFunction === fn
-                                            ? "bg-stone-700 text-stone-100"
-                                            : "bg-stone-200 text-stone-500 hover:bg-stone-300"
+                                        params.dropOffFunction === fn ?
+                                            "bg-stone-700 text-stone-100"
+                                        :   "bg-stone-200 text-stone-500 hover:bg-stone-300"
                                     }`}
                                     onClick={() =>
                                         updateParam("dropOffFunction", fn)

--- a/src/adaptive-dither/adaptive-dither-main.tsx
+++ b/src/adaptive-dither/adaptive-dither-main.tsx
@@ -1,5 +1,5 @@
+import { App } from "@/adaptive-dither/App";
 import { assertExists } from "@/lib/assert";
 import { createRoot } from "react-dom/client";
-import { App } from "@/adaptive-dither/App";
 
 createRoot(assertExists(document.getElementById("root"))).render(<App />);

--- a/src/adaptive-dither/adaptive-dither-main.tsx
+++ b/src/adaptive-dither/adaptive-dither-main.tsx
@@ -1,0 +1,5 @@
+import { assertExists } from "@/lib/assert";
+import { createRoot } from "react-dom/client";
+import { App } from "@/adaptive-dither/App";
+
+createRoot(assertExists(document.getElementById("root"))).render(<App />);

--- a/src/adaptive-dither/gpuPipeline.ts
+++ b/src/adaptive-dither/gpuPipeline.ts
@@ -3,12 +3,12 @@
  * Uses WebGL2 with the project's GL helpers for shader programs and textures,
  * plus raw WebGL for framebuffer management.
  *
- * Pipeline (GPU portion):
+ * Pipeline (GPU):
  *   Pass 1: Brightness/contrast (fragment shader)
  *   Pass 2: Sobel edge detection (fragment shader)
+ *   Pass 3: Modified JFA contrast map (multi-pass ping-pong)
  *
- * Passes 3-4 (contrast map, adaptive dither) run on the CPU and upload
- * results back to FBO textures so displayPass still works uniformly.
+ * Pass 4 (adaptive dither) runs on CPU and uploads results back.
  */
 
 import type { ProcessingParams } from "@/adaptive-dither/processing";
@@ -77,6 +77,117 @@ const EDGE_DETECT_FRAG = glsl`#version 300 es
     }
 `;
 
+// ── Pass 3: Modified JFA for contrast map ───────────────────────────────
+
+// Shared drop-off function used by JFA step and resolve shaders.
+// t is normalized distance: pixelDist / radius.
+const DROPOFF_GLSL = glsl`
+    float applyDropOff(float t, int fn) {
+        if (fn == 0) { // linear
+            return max(0.0, 1.0 - t);
+        } else if (fn == 1) { // exponential
+            return exp(-3.0 * t);
+        } else if (fn == 2) { // quadratic
+            return max(0.0, 1.0 - t * t);
+        } else { // sine
+            return t >= 1.0 ? 0.0 : cos(t * 1.5707963);
+        }
+    }
+`;
+
+// 3a: Seed — initialize JFA field from edge pixels
+const JFA_SEED_FRAG = glsl`#version 300 es
+    precision highp float;
+    in vec2 v_uv;
+    out vec4 fragColor;
+    uniform sampler2D u_edges;
+    uniform float u_threshold;
+
+    void main() {
+        float edge = texture(u_edges, v_uv).r;
+        if (edge > u_threshold) {
+            fragColor = vec4(v_uv, edge, 1.0);
+        } else {
+            fragColor = vec4(-1.0, -1.0, 0.0, 0.0);
+        }
+    }
+`;
+
+// 3b: Step — propagate best weighted source via jump flood
+const JFA_STEP_FRAG = glsl`#version 300 es
+    precision highp float;
+    in vec2 v_uv;
+    out vec4 fragColor;
+    uniform sampler2D u_jfa;
+    uniform vec2 u_texelSize;
+    uniform float u_stepSize;
+    uniform vec2 u_resolution;
+    uniform float u_radius;
+    uniform int u_dropOffFunction;
+
+    ${DROPOFF_GLSL}
+
+    float weightedValue(vec4 src) {
+        if (src.w < 0.5) return -1.0;
+        float pixelDist = distance(v_uv * u_resolution, src.xy * u_resolution);
+        float t = pixelDist / u_radius;
+        return src.z * applyDropOff(t, u_dropOffFunction);
+    }
+
+    void main() {
+        vec4 best = texture(u_jfa, v_uv);
+        float bestVal = weightedValue(best);
+
+        for (int dy = -1; dy <= 1; dy++) {
+            for (int dx = -1; dx <= 1; dx++) {
+                if (dx == 0 && dy == 0) continue;
+                vec2 sampleUV = v_uv + vec2(float(dx), float(dy)) * u_stepSize * u_texelSize;
+                vec4 s = texture(u_jfa, sampleUV);
+                float val = weightedValue(s);
+                if (val > bestVal) {
+                    bestVal = val;
+                    best = s;
+                }
+            }
+        }
+        fragColor = best;
+    }
+`;
+
+// 3c: Resolve — convert JFA source field to scalar contrast map
+const JFA_RESOLVE_FRAG = glsl`#version 300 es
+    precision highp float;
+    in vec2 v_uv;
+    out vec4 fragColor;
+    uniform sampler2D u_jfa;
+    uniform vec2 u_resolution;
+    uniform float u_radius;
+    uniform int u_dropOffFunction;
+
+    ${DROPOFF_GLSL}
+
+    void main() {
+        vec4 jfa = texture(u_jfa, v_uv);
+        if (jfa.w < 0.5) {
+            fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+            return;
+        }
+        float pixelDist = distance(v_uv * u_resolution, jfa.xy * u_resolution);
+        float t = pixelDist / u_radius;
+        float val = jfa.z * applyDropOff(t, u_dropOffFunction);
+        fragColor = vec4(val, val, val, 1.0);
+    }
+`;
+
+// ── Drop-off function index mapping ─────────────────────────────────────
+
+const DROP_OFF_FN_INDEX: Record<ProcessingParams["dropOffFunction"], number> = {
+    linear: 0,
+    exponential: 1,
+    quadratic: 2,
+    sine: 3,
+};
+
 // ── Pipeline class ──────────────────────────────────────────────────────
 
 export class DitherPipeline {
@@ -86,6 +197,9 @@ export class DitherPipeline {
     // Programs
     private brightnessContrastProg: GlProgram;
     private edgeDetectProg: GlProgram;
+    private jfaSeedProg: GlProgram;
+    private jfaStepProg: GlProgram;
+    private jfaResolveProg: GlProgram;
     private displayProg: GlProgram;
 
     // Fullscreen quad
@@ -96,7 +210,11 @@ export class DitherPipeline {
     private fbos: WebGLFramebuffer[] = [];
     private fboTextures: WebGLTexture[] = [];
 
-    // Texture units for the source image
+    // JFA ping-pong framebuffers (RGBA32F for UV + edge + flag)
+    private jfaFbos: [WebGLFramebuffer, WebGLFramebuffer] = [null!, null!];
+    private jfaTextures: [WebGLTexture, WebGLTexture] = [null!, null!];
+
+    // Source image texture
     private sourceTexture: WebGLTexture;
 
     private currentWidth = 0;
@@ -112,10 +230,9 @@ export class DitherPipeline {
         this.rawGl = this.glCtx.gl;
         const gl = this.rawGl;
 
-        // Required to render to RGBA16F / RGBA32F framebuffers
         gl.getExtension("EXT_color_buffer_float");
 
-        // Create shader programs (passes 1-2 + display)
+        // Create all shader programs
         this.brightnessContrastProg = this.glCtx.createProgram({
             vertex: FULLSCREEN_VERT,
             fragment: BRIGHTNESS_CONTRAST_FRAG,
@@ -123,6 +240,18 @@ export class DitherPipeline {
         this.edgeDetectProg = this.glCtx.createProgram({
             vertex: FULLSCREEN_VERT,
             fragment: EDGE_DETECT_FRAG,
+        });
+        this.jfaSeedProg = this.glCtx.createProgram({
+            vertex: FULLSCREEN_VERT,
+            fragment: JFA_SEED_FRAG,
+        });
+        this.jfaStepProg = this.glCtx.createProgram({
+            vertex: FULLSCREEN_VERT,
+            fragment: JFA_STEP_FRAG,
+        });
+        this.jfaResolveProg = this.glCtx.createProgram({
+            vertex: FULLSCREEN_VERT,
+            fragment: JFA_RESOLVE_FRAG,
         });
         this.displayProg = this.glCtx.createProgram({
             vertex: FULLSCREEN_VERT,
@@ -158,6 +287,12 @@ export class DitherPipeline {
             const tex = assertExists(gl.createTexture());
             this.fbos.push(fbo);
             this.fboTextures.push(tex);
+        }
+
+        // JFA ping-pong framebuffers
+        for (let i = 0; i < 2; i++) {
+            this.jfaFbos[i] = assertExists(gl.createFramebuffer());
+            this.jfaTextures[i] = assertExists(gl.createTexture());
         }
     }
 
@@ -215,6 +350,26 @@ export class DitherPipeline {
             );
         }
 
+        // JFA FBOs (RGBA32F for storing UV coords + edge value + flag)
+        for (let i = 0; i < 2; i++) {
+            this.setupTexture(
+                this.jfaTextures[i],
+                width,
+                height,
+                gl.RGBA32F,
+                gl.RGBA,
+                gl.FLOAT,
+            );
+            gl.bindFramebuffer(gl.FRAMEBUFFER, this.jfaFbos[i]);
+            gl.framebufferTexture2D(
+                gl.FRAMEBUFFER,
+                gl.COLOR_ATTACHMENT0,
+                gl.TEXTURE_2D,
+                this.jfaTextures[i],
+                0,
+            );
+        }
+
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
     }
 
@@ -260,7 +415,7 @@ export class DitherPipeline {
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     }
 
-    /** Run GPU passes 1-2 only (brightness/contrast + edge detection). */
+    /** Run GPU passes 1-3 (brightness/contrast, edge detection, JFA contrast map). */
     runGpuPasses(params: ProcessingParams) {
         const gl = this.rawGl;
         const w = this.currentWidth;
@@ -299,6 +454,71 @@ export class DitherPipeline {
             params.edgeStrength,
         );
         this.drawQuad(ed, this.fbos[DitherPipeline.PASS_EDGES]);
+
+        // ── Pass 3: Modified JFA Contrast Map ───────────────────────
+
+        // 3a: Seed from edge pixels
+        this.bindTextureToUnit(this.fboTextures[DitherPipeline.PASS_EDGES], 0);
+        const seed = this.jfaSeedProg;
+        gl.useProgram(seed.program);
+        gl.uniform1i(gl.getUniformLocation(seed.program, "u_edges"), 0);
+        gl.uniform1f(gl.getUniformLocation(seed.program, "u_threshold"), 0.05);
+        this.drawQuad(seed, this.jfaFbos[0]);
+
+        // 3b: JFA step passes (ping-pong)
+        const maxDim = Math.max(w, h);
+        let stepSize = Math.pow(2, Math.ceil(Math.log2(maxDim)) - 1);
+        let readIdx = 0;
+        const dropOffIdx = DROP_OFF_FN_INDEX[params.dropOffFunction];
+
+        while (stepSize >= 1) {
+            const writeIdx = 1 - readIdx;
+            this.bindTextureToUnit(this.jfaTextures[readIdx], 0);
+            const step = this.jfaStepProg;
+            gl.useProgram(step.program);
+            gl.uniform1i(gl.getUniformLocation(step.program, "u_jfa"), 0);
+            gl.uniform2f(
+                gl.getUniformLocation(step.program, "u_texelSize"),
+                1 / w,
+                1 / h,
+            );
+            gl.uniform1f(
+                gl.getUniformLocation(step.program, "u_stepSize"),
+                stepSize,
+            );
+            gl.uniform2f(
+                gl.getUniformLocation(step.program, "u_resolution"),
+                w,
+                h,
+            );
+            gl.uniform1f(
+                gl.getUniformLocation(step.program, "u_radius"),
+                params.radius,
+            );
+            gl.uniform1i(
+                gl.getUniformLocation(step.program, "u_dropOffFunction"),
+                dropOffIdx,
+            );
+            this.drawQuad(step, this.jfaFbos[writeIdx]);
+            readIdx = writeIdx;
+            stepSize = Math.floor(stepSize / 2);
+        }
+
+        // 3c: Resolve to contrast map
+        this.bindTextureToUnit(this.jfaTextures[readIdx], 0);
+        const res = this.jfaResolveProg;
+        gl.useProgram(res.program);
+        gl.uniform1i(gl.getUniformLocation(res.program, "u_jfa"), 0);
+        gl.uniform2f(gl.getUniformLocation(res.program, "u_resolution"), w, h);
+        gl.uniform1f(
+            gl.getUniformLocation(res.program, "u_radius"),
+            params.radius,
+        );
+        gl.uniform1i(
+            gl.getUniformLocation(res.program, "u_dropOffFunction"),
+            dropOffIdx,
+        );
+        this.drawQuad(res, this.fbos[DitherPipeline.PASS_CONTRAST_MAP]);
     }
 
     /**
@@ -319,29 +539,6 @@ export class DitherPipeline {
             result[i] = rgba[i * 4];
         }
         return result;
-    }
-
-    /**
-     * Upload a grayscale Float32Array to a pass FBO texture as RGBA16F.
-     * Expands the single channel to RGB so displayPass works.
-     */
-    uploadGrayscaleToPass(passIndex: number, data: Float32Array) {
-        const gl = this.rawGl;
-        const w = this.currentWidth;
-        const h = this.currentHeight;
-
-        // Expand grayscale to RGBA
-        const rgba = new Float32Array(w * h * 4);
-        for (let i = 0; i < w * h; i++) {
-            const v = data[i];
-            rgba[i * 4] = v;
-            rgba[i * 4 + 1] = v;
-            rgba[i * 4 + 2] = v;
-            rgba[i * 4 + 3] = 1;
-        }
-
-        gl.bindTexture(gl.TEXTURE_2D, this.fboTextures[passIndex]);
-        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, w, h, gl.RGBA, gl.FLOAT, rgba);
     }
 
     /**
@@ -384,7 +581,6 @@ export class DitherPipeline {
     ) {
         const gl = this.rawGl;
 
-        // Only resize if needed — setting width/height clears the WebGL state
         if (
             this.canvas.width !== this.currentWidth ||
             this.canvas.height !== this.currentHeight
@@ -428,6 +624,8 @@ export class DitherPipeline {
         const gl = this.rawGl;
         for (const fbo of this.fbos) gl.deleteFramebuffer(fbo);
         for (const tex of this.fboTextures) gl.deleteTexture(tex);
+        for (const fbo of this.jfaFbos) gl.deleteFramebuffer(fbo);
+        for (const tex of this.jfaTextures) gl.deleteTexture(tex);
         gl.deleteTexture(this.sourceTexture);
         this.glCtx.destroy();
     }

--- a/src/adaptive-dither/gpuPipeline.ts
+++ b/src/adaptive-dither/gpuPipeline.ts
@@ -1,13 +1,14 @@
 /** GPU-accelerated image processing pipeline for adaptive dithering.
  *
  * Uses WebGL2 with the project's GL helpers for shader programs and textures,
- * plus raw WebGL for framebuffer ping-pong (not covered by the helpers).
+ * plus raw WebGL for framebuffer management.
  *
- * Pipeline:
+ * Pipeline (GPU portion):
  *   Pass 1: Brightness/contrast (fragment shader)
  *   Pass 2: Sobel edge detection (fragment shader)
- *   Pass 3: Jump Flood Algorithm to propagate contrast (multi-pass ping-pong)
- *   Pass 4: Adaptive Bayer dithering at varying block sizes (fragment shader)
+ *
+ * Passes 3-4 (contrast map, adaptive dither) run on the CPU and upload
+ * results back to FBO textures so displayPass still works uniformly.
  */
 
 import type { ProcessingParams } from "@/adaptive-dither/processing";
@@ -76,174 +77,7 @@ const EDGE_DETECT_FRAG = glsl`#version 300 es
     }
 `;
 
-// ── Pass 3a: JFA seed (initialize jump-flood from edge pixels) ──────────
-
-const JFA_SEED_FRAG = glsl`#version 300 es
-    precision highp float;
-    in vec2 v_uv;
-    out vec4 fragColor;
-    uniform sampler2D u_edges;
-    uniform float u_threshold;
-
-    void main() {
-        float edge = texture(u_edges, v_uv).r;
-        if (edge > u_threshold) {
-            // Store this pixel's UV coords and edge value
-            fragColor = vec4(v_uv, edge, 1.0);
-        } else {
-            // Sentinel: no source assigned yet
-            fragColor = vec4(-1.0, -1.0, 0.0, 0.0);
-        }
-    }
-`;
-
-// ── Pass 3b: JFA step ───────────────────────────────────────────────────
-
-const JFA_STEP_FRAG = glsl`#version 300 es
-    precision highp float;
-    in vec2 v_uv;
-    out vec4 fragColor;
-    uniform sampler2D u_jfa;
-    uniform vec2 u_texelSize;
-    uniform float u_stepSize;
-
-    void main() {
-        vec4 best = texture(u_jfa, v_uv);
-        float bestDist = best.w > 0.5 ? distance(v_uv, best.xy) : 1e10;
-
-        for (int dy = -1; dy <= 1; dy++) {
-            for (int dx = -1; dx <= 1; dx++) {
-                if (dx == 0 && dy == 0) continue;
-                vec2 sampleUV = v_uv + vec2(float(dx), float(dy)) * u_stepSize * u_texelSize;
-                vec4 s = texture(u_jfa, sampleUV);
-                if (s.w > 0.5) {
-                    float d = distance(v_uv, s.xy);
-                    if (d < bestDist) {
-                        bestDist = d;
-                        best = s;
-                    }
-                }
-            }
-        }
-        fragColor = best;
-    }
-`;
-
-// ── Pass 3c: JFA resolve (convert JFA result to contrast map) ───────────
-
-const JFA_RESOLVE_FRAG = glsl`#version 300 es
-    precision highp float;
-    in vec2 v_uv;
-    out vec4 fragColor;
-    uniform sampler2D u_jfa;
-    uniform vec2 u_resolution;
-    uniform float u_dropOffRate;
-    uniform int u_dropOffFunction; // 0=linear, 1=exp, 2=quadratic, 3=sine
-
-    float applyDropOff(float dist, float rate) {
-        if (u_dropOffFunction == 0) {
-            return max(0.0, 1.0 - dist * rate);
-        } else if (u_dropOffFunction == 1) {
-            return exp(-dist * rate);
-        } else if (u_dropOffFunction == 2) {
-            float v = dist * rate;
-            return max(0.0, 1.0 - v * v);
-        } else {
-            float v = dist * rate;
-            return v >= 1.0 ? 0.0 : cos(v * 1.5707963);
-        }
-    }
-
-    void main() {
-        vec4 jfa = texture(u_jfa, v_uv);
-        if (jfa.w < 0.5) {
-            fragColor = vec4(0.0, 0.0, 0.0, 1.0);
-            return;
-        }
-        float pixelDist = distance(v_uv * u_resolution, jfa.xy * u_resolution);
-        float srcEdge = jfa.z;
-        float val = srcEdge * applyDropOff(pixelDist, u_dropOffRate);
-        fragColor = vec4(val, val, val, 1.0);
-    }
-`;
-
-// ── Pass 4: Adaptive Bayer dithering ────────────────────────────────────
-
-const ADAPTIVE_DITHER_FRAG = glsl`#version 300 es
-    precision highp float;
-    in vec2 v_uv;
-    out vec4 fragColor;
-    uniform sampler2D u_preprocessed;
-    uniform sampler2D u_contrastMap;
-    uniform vec2 u_resolution;
-    uniform int u_maxLevels;
-    uniform float u_rangeLow;
-    uniform float u_rangeHigh;
-
-    // 8x8 Bayer matrix (normalized to [0, 1))
-    float bayer8(vec2 pos) {
-        ivec2 p = ivec2(pos) & 7;
-        int idx = p.x + p.y * 8;
-        // Precomputed 8x8 Bayer matrix
-        int b8[64] = int[64](
-             0, 32,  8, 40,  2, 34, 10, 42,
-            48, 16, 56, 24, 50, 18, 58, 26,
-            12, 44,  4, 36, 14, 46,  6, 38,
-            60, 28, 52, 20, 62, 30, 54, 22,
-             3, 35, 11, 43,  1, 33,  9, 41,
-            51, 19, 59, 27, 49, 17, 57, 25,
-            15, 47,  7, 39, 13, 45,  5, 37,
-            63, 31, 55, 23, 61, 29, 53, 21
-        );
-        return (float(b8[idx]) + 0.5) / 64.0;
-    }
-
-    // Dither at a given block size using Bayer pattern
-    float ditherAtBlock(vec2 pixelCoord, float gray, int blockSize) {
-        // Quantize pixel to block grid
-        vec2 blockCoord = floor(pixelCoord / float(blockSize));
-        // Average the block: sample at block center
-        vec2 blockCenter = (blockCoord + 0.5) * float(blockSize) / u_resolution;
-        float blockGray = texture(u_preprocessed, blockCenter).r;
-        // Apply Bayer threshold within the block
-        vec2 posInBlock = mod(pixelCoord, float(blockSize));
-        float threshold = bayer8(posInBlock * (8.0 / float(blockSize)));
-        return step(threshold, blockGray);
-    }
-
-    void main() {
-        float contrast = texture(u_contrastMap, v_uv).r;
-        vec2 pixelCoord = v_uv * u_resolution;
-        float gray = texture(u_preprocessed, v_uv).r;
-
-        // Map contrast to level index
-        float t;
-        if (contrast >= u_rangeHigh) {
-            t = 0.0;
-        } else if (contrast <= u_rangeLow) {
-            t = 1.0;
-        } else {
-            t = 1.0 - (contrast - u_rangeLow) / (u_rangeHigh - u_rangeLow);
-        }
-
-        float levelFloat = t * float(u_maxLevels - 1);
-        int level = int(round(levelFloat));
-        level = min(level, u_maxLevels - 1);
-        int blockSize = 1 << level;
-
-        float result = ditherAtBlock(pixelCoord, gray, blockSize);
-        fragColor = vec4(result, result, result, 1.0);
-    }
-`;
-
 // ── Pipeline class ──────────────────────────────────────────────────────
-
-const DROP_OFF_FN_INDEX: Record<ProcessingParams["dropOffFunction"], number> = {
-    linear: 0,
-    exponential: 1,
-    quadratic: 2,
-    sine: 3,
-};
 
 export class DitherPipeline {
     private glCtx: Gl;
@@ -252,20 +86,15 @@ export class DitherPipeline {
     // Programs
     private brightnessContrastProg: GlProgram;
     private edgeDetectProg: GlProgram;
-    private jfaSeedProg: GlProgram;
-    private jfaStepProg: GlProgram;
-    private jfaResolveProg: GlProgram;
-    private adaptiveDitherProg: GlProgram;
     private displayProg: GlProgram;
 
     // Fullscreen quad
     private quadVao: GlVertexArray;
 
     // Framebuffers + textures (managed manually)
+    // 0 = preprocessed, 1 = edges, 2 = contrastMap, 3 = dithered
     private fbos: WebGLFramebuffer[] = [];
     private fboTextures: WebGLTexture[] = [];
-    private jfaFbos: [WebGLFramebuffer, WebGLFramebuffer] = [null!, null!];
-    private jfaTextures: [WebGLTexture, WebGLTexture] = [null!, null!];
 
     // Texture units for the source image
     private sourceTexture: WebGLTexture;
@@ -273,12 +102,10 @@ export class DitherPipeline {
     private currentWidth = 0;
     private currentHeight = 0;
 
-    // Pass indices into fbos/fboTextures:
-    // 0 = preprocessed, 1 = edges, 2 = contrastMap, 3 = dithered
-    private static readonly PASS_PREPROCESSED = 0;
-    private static readonly PASS_EDGES = 1;
-    private static readonly PASS_CONTRAST_MAP = 2;
-    private static readonly PASS_DITHERED = 3;
+    static readonly PASS_PREPROCESSED = 0;
+    static readonly PASS_EDGES = 1;
+    static readonly PASS_CONTRAST_MAP = 2;
+    static readonly PASS_DITHERED = 3;
 
     constructor(private canvas: HTMLCanvasElement) {
         this.glCtx = new Gl(canvas);
@@ -288,7 +115,7 @@ export class DitherPipeline {
         // Required to render to RGBA16F / RGBA32F framebuffers
         gl.getExtension("EXT_color_buffer_float");
 
-        // Create all shader programs
+        // Create shader programs (passes 1-2 + display)
         this.brightnessContrastProg = this.glCtx.createProgram({
             vertex: FULLSCREEN_VERT,
             fragment: BRIGHTNESS_CONTRAST_FRAG,
@@ -296,22 +123,6 @@ export class DitherPipeline {
         this.edgeDetectProg = this.glCtx.createProgram({
             vertex: FULLSCREEN_VERT,
             fragment: EDGE_DETECT_FRAG,
-        });
-        this.jfaSeedProg = this.glCtx.createProgram({
-            vertex: FULLSCREEN_VERT,
-            fragment: JFA_SEED_FRAG,
-        });
-        this.jfaStepProg = this.glCtx.createProgram({
-            vertex: FULLSCREEN_VERT,
-            fragment: JFA_STEP_FRAG,
-        });
-        this.jfaResolveProg = this.glCtx.createProgram({
-            vertex: FULLSCREEN_VERT,
-            fragment: JFA_RESOLVE_FRAG,
-        });
-        this.adaptiveDitherProg = this.glCtx.createProgram({
-            vertex: FULLSCREEN_VERT,
-            fragment: ADAPTIVE_DITHER_FRAG,
         });
         this.displayProg = this.glCtx.createProgram({
             vertex: FULLSCREEN_VERT,
@@ -326,8 +137,7 @@ export class DitherPipeline {
             `,
         });
 
-        // Fullscreen quad VAO (shared across all programs)
-        // We'll bind it manually to each program
+        // Fullscreen quad VAO
         this.quadVao =
             this.brightnessContrastProg.createAndBindVertexArrayObject({
                 name: "a_position",
@@ -348,12 +158,6 @@ export class DitherPipeline {
             const tex = assertExists(gl.createTexture());
             this.fbos.push(fbo);
             this.fboTextures.push(tex);
-        }
-
-        // JFA ping-pong framebuffers
-        for (let i = 0; i < 2; i++) {
-            this.jfaFbos[i] = assertExists(gl.createFramebuffer());
-            this.jfaTextures[i] = assertExists(gl.createTexture());
         }
     }
 
@@ -411,26 +215,6 @@ export class DitherPipeline {
             );
         }
 
-        // JFA FBOs (RGBA32F for storing UV coords + edge value + flag)
-        for (let i = 0; i < 2; i++) {
-            this.setupTexture(
-                this.jfaTextures[i],
-                width,
-                height,
-                gl.RGBA32F,
-                gl.RGBA,
-                gl.FLOAT,
-            );
-            gl.bindFramebuffer(gl.FRAMEBUFFER, this.jfaFbos[i]);
-            gl.framebufferTexture2D(
-                gl.FRAMEBUFFER,
-                gl.COLOR_ATTACHMENT0,
-                gl.TEXTURE_2D,
-                this.jfaTextures[i],
-                0,
-            );
-        }
-
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
     }
 
@@ -453,7 +237,6 @@ export class DitherPipeline {
         const gl = this.rawGl;
         this.resizeBuffers(width, height);
 
-        // Draw image to an offscreen canvas at the target size, then upload
         const offscreen = document.createElement("canvas");
         offscreen.width = width;
         offscreen.height = height;
@@ -461,6 +244,7 @@ export class DitherPipeline {
         ctx.drawImage(image, 0, 0, width, height);
 
         gl.bindTexture(gl.TEXTURE_2D, this.sourceTexture);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
         gl.texImage2D(
             gl.TEXTURE_2D,
             0,
@@ -469,13 +253,15 @@ export class DitherPipeline {
             gl.UNSIGNED_BYTE,
             offscreen,
         );
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     }
 
-    runPipeline(params: ProcessingParams) {
+    /** Run GPU passes 1-2 only (brightness/contrast + edge detection). */
+    runGpuPasses(params: ProcessingParams) {
         const gl = this.rawGl;
         const w = this.currentWidth;
         const h = this.currentHeight;
@@ -513,85 +299,78 @@ export class DitherPipeline {
             params.edgeStrength,
         );
         this.drawQuad(ed, this.fbos[DitherPipeline.PASS_EDGES]);
+    }
 
-        // ── Pass 3: Jump Flood Algorithm ────────────────────────────
+    /**
+     * Read the R channel from a pass FBO as a Float32Array.
+     * Reads RGBA float pixels and extracts the red channel.
+     */
+    readPassPixels(passIndex: number): Float32Array {
+        const gl = this.rawGl;
+        const w = this.currentWidth;
+        const h = this.currentHeight;
 
-        // 3a: Seed
-        this.bindTextureToUnit(this.fboTextures[DitherPipeline.PASS_EDGES], 0);
-        const seed = this.jfaSeedProg;
-        gl.useProgram(seed.program);
-        gl.uniform1i(gl.getUniformLocation(seed.program, "u_edges"), 0);
-        gl.uniform1f(gl.getUniformLocation(seed.program, "u_threshold"), 0.05);
-        this.drawQuad(seed, this.jfaFbos[0]);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbos[passIndex]);
+        const rgba = new Float32Array(w * h * 4);
+        gl.readPixels(0, 0, w, h, gl.RGBA, gl.FLOAT, rgba);
 
-        // 3b: JFA steps (ping-pong)
-        const maxDim = Math.max(w, h);
-        let stepSize = Math.pow(2, Math.ceil(Math.log2(maxDim)) - 1);
-        let readIdx = 0;
+        const result = new Float32Array(w * h);
+        for (let i = 0; i < w * h; i++) {
+            result[i] = rgba[i * 4];
+        }
+        return result;
+    }
 
-        while (stepSize >= 1) {
-            const writeIdx = 1 - readIdx;
-            this.bindTextureToUnit(this.jfaTextures[readIdx], 0);
-            const step = this.jfaStepProg;
-            gl.useProgram(step.program);
-            gl.uniform1i(gl.getUniformLocation(step.program, "u_jfa"), 0);
-            gl.uniform2f(
-                gl.getUniformLocation(step.program, "u_texelSize"),
-                1 / w,
-                1 / h,
-            );
-            gl.uniform1f(
-                gl.getUniformLocation(step.program, "u_stepSize"),
-                stepSize,
-            );
-            this.drawQuad(step, this.jfaFbos[writeIdx]);
-            readIdx = writeIdx;
-            stepSize = Math.floor(stepSize / 2);
+    /**
+     * Upload a grayscale Float32Array to a pass FBO texture as RGBA16F.
+     * Expands the single channel to RGB so displayPass works.
+     */
+    uploadGrayscaleToPass(passIndex: number, data: Float32Array) {
+        const gl = this.rawGl;
+        const w = this.currentWidth;
+        const h = this.currentHeight;
+
+        // Expand grayscale to RGBA
+        const rgba = new Float32Array(w * h * 4);
+        for (let i = 0; i < w * h; i++) {
+            const v = data[i];
+            rgba[i * 4] = v;
+            rgba[i * 4 + 1] = v;
+            rgba[i * 4 + 2] = v;
+            rgba[i * 4 + 3] = 1;
         }
 
-        // 3c: Resolve to contrast map
-        this.bindTextureToUnit(this.jfaTextures[readIdx], 0);
-        const res = this.jfaResolveProg;
-        gl.useProgram(res.program);
-        gl.uniform1i(gl.getUniformLocation(res.program, "u_jfa"), 0);
-        gl.uniform2f(gl.getUniformLocation(res.program, "u_resolution"), w, h);
-        gl.uniform1f(
-            gl.getUniformLocation(res.program, "u_dropOffRate"),
-            params.dropOffRate,
-        );
-        gl.uniform1i(
-            gl.getUniformLocation(res.program, "u_dropOffFunction"),
-            DROP_OFF_FN_INDEX[params.dropOffFunction],
-        );
-        this.drawQuad(res, this.fbos[DitherPipeline.PASS_CONTRAST_MAP]);
+        gl.bindTexture(gl.TEXTURE_2D, this.fboTextures[passIndex]);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, w, h, gl.RGBA, gl.FLOAT, rgba);
+    }
 
-        // ── Pass 4: Adaptive Dithering ──────────────────────────────
-        this.bindTextureToUnit(
-            this.fboTextures[DitherPipeline.PASS_PREPROCESSED],
-            0,
-        );
-        this.bindTextureToUnit(
-            this.fboTextures[DitherPipeline.PASS_CONTRAST_MAP],
-            1,
-        );
-        const ad = this.adaptiveDitherProg;
-        gl.useProgram(ad.program);
-        gl.uniform1i(gl.getUniformLocation(ad.program, "u_preprocessed"), 0);
-        gl.uniform1i(gl.getUniformLocation(ad.program, "u_contrastMap"), 1);
-        gl.uniform2f(gl.getUniformLocation(ad.program, "u_resolution"), w, h);
-        gl.uniform1i(
-            gl.getUniformLocation(ad.program, "u_maxLevels"),
-            params.maxDitherLevels,
-        );
-        gl.uniform1f(
-            gl.getUniformLocation(ad.program, "u_rangeLow"),
-            params.contrastRangeLow,
-        );
-        gl.uniform1f(
-            gl.getUniformLocation(ad.program, "u_rangeHigh"),
-            params.contrastRangeHigh,
-        );
-        this.drawQuad(ad, this.fbos[DitherPipeline.PASS_DITHERED]);
+    /**
+     * Upload a Uint8Array (0 or 255) to a pass FBO texture as RGBA16F.
+     * Converts to [0, 1] float range.
+     */
+    uploadBinaryToPass(passIndex: number, data: Uint8Array) {
+        const gl = this.rawGl;
+        const w = this.currentWidth;
+        const h = this.currentHeight;
+
+        const rgba = new Float32Array(w * h * 4);
+        for (let i = 0; i < w * h; i++) {
+            const v = data[i] / 255;
+            rgba[i * 4] = v;
+            rgba[i * 4 + 1] = v;
+            rgba[i * 4 + 2] = v;
+            rgba[i * 4 + 3] = 1;
+        }
+
+        gl.bindTexture(gl.TEXTURE_2D, this.fboTextures[passIndex]);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, w, h, gl.RGBA, gl.FLOAT, rgba);
+    }
+
+    get width() {
+        return this.currentWidth;
+    }
+    get height() {
+        return this.currentHeight;
     }
 
     /** Display one of the pass results to the visible canvas. */
@@ -649,8 +428,6 @@ export class DitherPipeline {
         const gl = this.rawGl;
         for (const fbo of this.fbos) gl.deleteFramebuffer(fbo);
         for (const tex of this.fboTextures) gl.deleteTexture(tex);
-        for (const fbo of this.jfaFbos) gl.deleteFramebuffer(fbo);
-        for (const tex of this.jfaTextures) gl.deleteTexture(tex);
         gl.deleteTexture(this.sourceTexture);
         this.glCtx.destroy();
     }

--- a/src/adaptive-dither/gpuPipeline.ts
+++ b/src/adaptive-dither/gpuPipeline.ts
@@ -20,7 +20,7 @@ import type { GlVertexArray } from "@/lib/gl/GlVertexArray";
 // ── shared vertex shader (fullscreen quad) ──────────────────────────────
 
 const FULLSCREEN_VERT = glsl`#version 300 es
-    in vec2 a_position;
+    layout(location = 0) in vec2 a_position;
     out vec2 v_uv;
     void main() {
         v_uv = a_position;
@@ -284,6 +284,9 @@ export class DitherPipeline {
         this.glCtx = new Gl(canvas);
         this.rawGl = this.glCtx.gl;
         const gl = this.rawGl;
+
+        // Required to render to RGBA16F / RGBA32F framebuffers
+        gl.getExtension("EXT_color_buffer_float");
 
         // Create all shader programs
         this.brightnessContrastProg = this.glCtx.createProgram({
@@ -601,8 +604,15 @@ export class DitherPipeline {
             | "dithered",
     ) {
         const gl = this.rawGl;
-        this.canvas.width = this.currentWidth;
-        this.canvas.height = this.currentHeight;
+
+        // Only resize if needed — setting width/height clears the WebGL state
+        if (
+            this.canvas.width !== this.currentWidth ||
+            this.canvas.height !== this.currentHeight
+        ) {
+            this.canvas.width = this.currentWidth;
+            this.canvas.height = this.currentHeight;
+        }
 
         let tex: WebGLTexture;
         switch (pass) {

--- a/src/adaptive-dither/gpuPipeline.ts
+++ b/src/adaptive-dither/gpuPipeline.ts
@@ -1,0 +1,647 @@
+/** GPU-accelerated image processing pipeline for adaptive dithering.
+ *
+ * Uses WebGL2 with the project's GL helpers for shader programs and textures,
+ * plus raw WebGL for framebuffer ping-pong (not covered by the helpers).
+ *
+ * Pipeline:
+ *   Pass 1: Brightness/contrast (fragment shader)
+ *   Pass 2: Sobel edge detection (fragment shader)
+ *   Pass 3: Jump Flood Algorithm to propagate contrast (multi-pass ping-pong)
+ *   Pass 4: Adaptive Bayer dithering at varying block sizes (fragment shader)
+ */
+
+import type { ProcessingParams } from "@/adaptive-dither/processing";
+import { assertExists } from "@/lib/assert";
+import { Gl, glsl } from "@/lib/gl/Gl";
+import type { GlProgram } from "@/lib/gl/GlProgram";
+import { GlBufferUsage, GlVertexAttribType } from "@/lib/gl/GlTypes";
+import type { GlVertexArray } from "@/lib/gl/GlVertexArray";
+
+// ── shared vertex shader (fullscreen quad) ──────────────────────────────
+
+const FULLSCREEN_VERT = glsl`#version 300 es
+    in vec2 a_position;
+    out vec2 v_uv;
+    void main() {
+        v_uv = a_position;
+        gl_Position = vec4(a_position * 2.0 - 1.0, 0.0, 1.0);
+    }
+`;
+
+// ── Pass 1: Brightness / Contrast ───────────────────────────────────────
+
+const BRIGHTNESS_CONTRAST_FRAG = glsl`#version 300 es
+    precision highp float;
+    in vec2 v_uv;
+    out vec4 fragColor;
+    uniform sampler2D u_source;
+    uniform float u_brightness;
+    uniform float u_contrast;
+
+    void main() {
+        vec4 c = texture(u_source, v_uv);
+        float gray = dot(c.rgb, vec3(0.299, 0.587, 0.114));
+        float factor = u_contrast >= 0.0 ? 1.0 + u_contrast * 3.0 : 1.0 + u_contrast;
+        gray += u_brightness;
+        gray = (gray - 0.5) * factor + 0.5;
+        gray = clamp(gray, 0.0, 1.0);
+        fragColor = vec4(gray, gray, gray, 1.0);
+    }
+`;
+
+// ── Pass 2: Sobel edge detection ────────────────────────────────────────
+
+const EDGE_DETECT_FRAG = glsl`#version 300 es
+    precision highp float;
+    in vec2 v_uv;
+    out vec4 fragColor;
+    uniform sampler2D u_source;
+    uniform vec2 u_texelSize;
+    uniform float u_strength;
+
+    void main() {
+        float tl = texture(u_source, v_uv + vec2(-1, -1) * u_texelSize).r;
+        float tc = texture(u_source, v_uv + vec2( 0, -1) * u_texelSize).r;
+        float tr = texture(u_source, v_uv + vec2( 1, -1) * u_texelSize).r;
+        float ml = texture(u_source, v_uv + vec2(-1,  0) * u_texelSize).r;
+        float mr = texture(u_source, v_uv + vec2( 1,  0) * u_texelSize).r;
+        float bl = texture(u_source, v_uv + vec2(-1,  1) * u_texelSize).r;
+        float bc = texture(u_source, v_uv + vec2( 0,  1) * u_texelSize).r;
+        float br = texture(u_source, v_uv + vec2( 1,  1) * u_texelSize).r;
+
+        float gx = -tl - 2.0*ml - bl + tr + 2.0*mr + br;
+        float gy = -tl - 2.0*tc - tr + bl + 2.0*bc + br;
+        float mag = length(vec2(gx, gy)) * u_strength;
+        fragColor = vec4(mag, mag, mag, 1.0);
+    }
+`;
+
+// ── Pass 3a: JFA seed (initialize jump-flood from edge pixels) ──────────
+
+const JFA_SEED_FRAG = glsl`#version 300 es
+    precision highp float;
+    in vec2 v_uv;
+    out vec4 fragColor;
+    uniform sampler2D u_edges;
+    uniform float u_threshold;
+
+    void main() {
+        float edge = texture(u_edges, v_uv).r;
+        if (edge > u_threshold) {
+            // Store this pixel's UV coords and edge value
+            fragColor = vec4(v_uv, edge, 1.0);
+        } else {
+            // Sentinel: no source assigned yet
+            fragColor = vec4(-1.0, -1.0, 0.0, 0.0);
+        }
+    }
+`;
+
+// ── Pass 3b: JFA step ───────────────────────────────────────────────────
+
+const JFA_STEP_FRAG = glsl`#version 300 es
+    precision highp float;
+    in vec2 v_uv;
+    out vec4 fragColor;
+    uniform sampler2D u_jfa;
+    uniform vec2 u_texelSize;
+    uniform float u_stepSize;
+
+    void main() {
+        vec4 best = texture(u_jfa, v_uv);
+        float bestDist = best.w > 0.5 ? distance(v_uv, best.xy) : 1e10;
+
+        for (int dy = -1; dy <= 1; dy++) {
+            for (int dx = -1; dx <= 1; dx++) {
+                if (dx == 0 && dy == 0) continue;
+                vec2 sampleUV = v_uv + vec2(float(dx), float(dy)) * u_stepSize * u_texelSize;
+                vec4 s = texture(u_jfa, sampleUV);
+                if (s.w > 0.5) {
+                    float d = distance(v_uv, s.xy);
+                    if (d < bestDist) {
+                        bestDist = d;
+                        best = s;
+                    }
+                }
+            }
+        }
+        fragColor = best;
+    }
+`;
+
+// ── Pass 3c: JFA resolve (convert JFA result to contrast map) ───────────
+
+const JFA_RESOLVE_FRAG = glsl`#version 300 es
+    precision highp float;
+    in vec2 v_uv;
+    out vec4 fragColor;
+    uniform sampler2D u_jfa;
+    uniform vec2 u_resolution;
+    uniform float u_dropOffRate;
+    uniform int u_dropOffFunction; // 0=linear, 1=exp, 2=quadratic, 3=sine
+
+    float applyDropOff(float dist, float rate) {
+        if (u_dropOffFunction == 0) {
+            return max(0.0, 1.0 - dist * rate);
+        } else if (u_dropOffFunction == 1) {
+            return exp(-dist * rate);
+        } else if (u_dropOffFunction == 2) {
+            float v = dist * rate;
+            return max(0.0, 1.0 - v * v);
+        } else {
+            float v = dist * rate;
+            return v >= 1.0 ? 0.0 : cos(v * 1.5707963);
+        }
+    }
+
+    void main() {
+        vec4 jfa = texture(u_jfa, v_uv);
+        if (jfa.w < 0.5) {
+            fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+            return;
+        }
+        float pixelDist = distance(v_uv * u_resolution, jfa.xy * u_resolution);
+        float srcEdge = jfa.z;
+        float val = srcEdge * applyDropOff(pixelDist, u_dropOffRate);
+        fragColor = vec4(val, val, val, 1.0);
+    }
+`;
+
+// ── Pass 4: Adaptive Bayer dithering ────────────────────────────────────
+
+const ADAPTIVE_DITHER_FRAG = glsl`#version 300 es
+    precision highp float;
+    in vec2 v_uv;
+    out vec4 fragColor;
+    uniform sampler2D u_preprocessed;
+    uniform sampler2D u_contrastMap;
+    uniform vec2 u_resolution;
+    uniform int u_maxLevels;
+    uniform float u_rangeLow;
+    uniform float u_rangeHigh;
+
+    // 8x8 Bayer matrix (normalized to [0, 1))
+    float bayer8(vec2 pos) {
+        ivec2 p = ivec2(pos) & 7;
+        int idx = p.x + p.y * 8;
+        // Precomputed 8x8 Bayer matrix
+        int b8[64] = int[64](
+             0, 32,  8, 40,  2, 34, 10, 42,
+            48, 16, 56, 24, 50, 18, 58, 26,
+            12, 44,  4, 36, 14, 46,  6, 38,
+            60, 28, 52, 20, 62, 30, 54, 22,
+             3, 35, 11, 43,  1, 33,  9, 41,
+            51, 19, 59, 27, 49, 17, 57, 25,
+            15, 47,  7, 39, 13, 45,  5, 37,
+            63, 31, 55, 23, 61, 29, 53, 21
+        );
+        return (float(b8[idx]) + 0.5) / 64.0;
+    }
+
+    // Dither at a given block size using Bayer pattern
+    float ditherAtBlock(vec2 pixelCoord, float gray, int blockSize) {
+        // Quantize pixel to block grid
+        vec2 blockCoord = floor(pixelCoord / float(blockSize));
+        // Average the block: sample at block center
+        vec2 blockCenter = (blockCoord + 0.5) * float(blockSize) / u_resolution;
+        float blockGray = texture(u_preprocessed, blockCenter).r;
+        // Apply Bayer threshold within the block
+        vec2 posInBlock = mod(pixelCoord, float(blockSize));
+        float threshold = bayer8(posInBlock * (8.0 / float(blockSize)));
+        return step(threshold, blockGray);
+    }
+
+    void main() {
+        float contrast = texture(u_contrastMap, v_uv).r;
+        vec2 pixelCoord = v_uv * u_resolution;
+        float gray = texture(u_preprocessed, v_uv).r;
+
+        // Map contrast to level index
+        float t;
+        if (contrast >= u_rangeHigh) {
+            t = 0.0;
+        } else if (contrast <= u_rangeLow) {
+            t = 1.0;
+        } else {
+            t = 1.0 - (contrast - u_rangeLow) / (u_rangeHigh - u_rangeLow);
+        }
+
+        float levelFloat = t * float(u_maxLevels - 1);
+        int level = int(round(levelFloat));
+        level = min(level, u_maxLevels - 1);
+        int blockSize = 1 << level;
+
+        float result = ditherAtBlock(pixelCoord, gray, blockSize);
+        fragColor = vec4(result, result, result, 1.0);
+    }
+`;
+
+// ── Pipeline class ──────────────────────────────────────────────────────
+
+const DROP_OFF_FN_INDEX: Record<ProcessingParams["dropOffFunction"], number> = {
+    linear: 0,
+    exponential: 1,
+    quadratic: 2,
+    sine: 3,
+};
+
+export class DitherPipeline {
+    private glCtx: Gl;
+    private rawGl: WebGL2RenderingContext;
+
+    // Programs
+    private brightnessContrastProg: GlProgram;
+    private edgeDetectProg: GlProgram;
+    private jfaSeedProg: GlProgram;
+    private jfaStepProg: GlProgram;
+    private jfaResolveProg: GlProgram;
+    private adaptiveDitherProg: GlProgram;
+    private displayProg: GlProgram;
+
+    // Fullscreen quad
+    private quadVao: GlVertexArray;
+
+    // Framebuffers + textures (managed manually)
+    private fbos: WebGLFramebuffer[] = [];
+    private fboTextures: WebGLTexture[] = [];
+    private jfaFbos: [WebGLFramebuffer, WebGLFramebuffer] = [null!, null!];
+    private jfaTextures: [WebGLTexture, WebGLTexture] = [null!, null!];
+
+    // Texture units for the source image
+    private sourceTexture: WebGLTexture;
+
+    private currentWidth = 0;
+    private currentHeight = 0;
+
+    // Pass indices into fbos/fboTextures:
+    // 0 = preprocessed, 1 = edges, 2 = contrastMap, 3 = dithered
+    private static readonly PASS_PREPROCESSED = 0;
+    private static readonly PASS_EDGES = 1;
+    private static readonly PASS_CONTRAST_MAP = 2;
+    private static readonly PASS_DITHERED = 3;
+
+    constructor(private canvas: HTMLCanvasElement) {
+        this.glCtx = new Gl(canvas);
+        this.rawGl = this.glCtx.gl;
+        const gl = this.rawGl;
+
+        // Create all shader programs
+        this.brightnessContrastProg = this.glCtx.createProgram({
+            vertex: FULLSCREEN_VERT,
+            fragment: BRIGHTNESS_CONTRAST_FRAG,
+        });
+        this.edgeDetectProg = this.glCtx.createProgram({
+            vertex: FULLSCREEN_VERT,
+            fragment: EDGE_DETECT_FRAG,
+        });
+        this.jfaSeedProg = this.glCtx.createProgram({
+            vertex: FULLSCREEN_VERT,
+            fragment: JFA_SEED_FRAG,
+        });
+        this.jfaStepProg = this.glCtx.createProgram({
+            vertex: FULLSCREEN_VERT,
+            fragment: JFA_STEP_FRAG,
+        });
+        this.jfaResolveProg = this.glCtx.createProgram({
+            vertex: FULLSCREEN_VERT,
+            fragment: JFA_RESOLVE_FRAG,
+        });
+        this.adaptiveDitherProg = this.glCtx.createProgram({
+            vertex: FULLSCREEN_VERT,
+            fragment: ADAPTIVE_DITHER_FRAG,
+        });
+        this.displayProg = this.glCtx.createProgram({
+            vertex: FULLSCREEN_VERT,
+            fragment: glsl`#version 300 es
+                precision highp float;
+                in vec2 v_uv;
+                out vec4 fragColor;
+                uniform sampler2D u_source;
+                void main() {
+                    fragColor = texture(u_source, v_uv);
+                }
+            `,
+        });
+
+        // Fullscreen quad VAO (shared across all programs)
+        // We'll bind it manually to each program
+        this.quadVao =
+            this.brightnessContrastProg.createAndBindVertexArrayObject({
+                name: "a_position",
+                size: 2,
+                type: GlVertexAttribType.Float,
+            });
+        this.quadVao.bufferData(
+            new Float32Array([0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 1]),
+            GlBufferUsage.StaticDraw,
+        );
+
+        // Source image texture
+        this.sourceTexture = assertExists(gl.createTexture());
+
+        // Create pass framebuffers (4 passes)
+        for (let i = 0; i < 4; i++) {
+            const fbo = assertExists(gl.createFramebuffer());
+            const tex = assertExists(gl.createTexture());
+            this.fbos.push(fbo);
+            this.fboTextures.push(tex);
+        }
+
+        // JFA ping-pong framebuffers
+        for (let i = 0; i < 2; i++) {
+            this.jfaFbos[i] = assertExists(gl.createFramebuffer());
+            this.jfaTextures[i] = assertExists(gl.createTexture());
+        }
+    }
+
+    private setupTexture(
+        texture: WebGLTexture,
+        width: number,
+        height: number,
+        internalFormat: number,
+        format: number,
+        type: number,
+    ) {
+        const gl = this.rawGl;
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            internalFormat,
+            width,
+            height,
+            0,
+            format,
+            type,
+            null,
+        );
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    }
+
+    private resizeBuffers(width: number, height: number) {
+        if (width === this.currentWidth && height === this.currentHeight)
+            return;
+        this.currentWidth = width;
+        this.currentHeight = height;
+        const gl = this.rawGl;
+
+        // Pass FBOs (RGBA16F for precision)
+        for (let i = 0; i < 4; i++) {
+            this.setupTexture(
+                this.fboTextures[i],
+                width,
+                height,
+                gl.RGBA16F,
+                gl.RGBA,
+                gl.HALF_FLOAT,
+            );
+            gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbos[i]);
+            gl.framebufferTexture2D(
+                gl.FRAMEBUFFER,
+                gl.COLOR_ATTACHMENT0,
+                gl.TEXTURE_2D,
+                this.fboTextures[i],
+                0,
+            );
+        }
+
+        // JFA FBOs (RGBA32F for storing UV coords + edge value + flag)
+        for (let i = 0; i < 2; i++) {
+            this.setupTexture(
+                this.jfaTextures[i],
+                width,
+                height,
+                gl.RGBA32F,
+                gl.RGBA,
+                gl.FLOAT,
+            );
+            gl.bindFramebuffer(gl.FRAMEBUFFER, this.jfaFbos[i]);
+            gl.framebufferTexture2D(
+                gl.FRAMEBUFFER,
+                gl.COLOR_ATTACHMENT0,
+                gl.TEXTURE_2D,
+                this.jfaTextures[i],
+                0,
+            );
+        }
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    }
+
+    private drawQuad(program: GlProgram, targetFbo: WebGLFramebuffer | null) {
+        const gl = this.rawGl;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, targetFbo);
+        gl.viewport(0, 0, this.currentWidth, this.currentHeight);
+        program.use();
+        this.quadVao.bindVao();
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    private bindTextureToUnit(texture: WebGLTexture, unit: number) {
+        const gl = this.rawGl;
+        gl.activeTexture(gl.TEXTURE0 + unit);
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+    }
+
+    uploadImage(image: HTMLImageElement, width: number, height: number) {
+        const gl = this.rawGl;
+        this.resizeBuffers(width, height);
+
+        // Draw image to an offscreen canvas at the target size, then upload
+        const offscreen = document.createElement("canvas");
+        offscreen.width = width;
+        offscreen.height = height;
+        const ctx = offscreen.getContext("2d")!;
+        ctx.drawImage(image, 0, 0, width, height);
+
+        gl.bindTexture(gl.TEXTURE_2D, this.sourceTexture);
+        gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA8,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            offscreen,
+        );
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    }
+
+    runPipeline(params: ProcessingParams) {
+        const gl = this.rawGl;
+        const w = this.currentWidth;
+        const h = this.currentHeight;
+
+        // ── Pass 1: Brightness / Contrast ───────────────────────────
+        this.bindTextureToUnit(this.sourceTexture, 0);
+        const bc = this.brightnessContrastProg;
+        gl.useProgram(bc.program);
+        gl.uniform1i(gl.getUniformLocation(bc.program, "u_source"), 0);
+        gl.uniform1f(
+            gl.getUniformLocation(bc.program, "u_brightness"),
+            params.brightness,
+        );
+        gl.uniform1f(
+            gl.getUniformLocation(bc.program, "u_contrast"),
+            params.contrast,
+        );
+        this.drawQuad(bc, this.fbos[DitherPipeline.PASS_PREPROCESSED]);
+
+        // ── Pass 2: Edge Detection ──────────────────────────────────
+        this.bindTextureToUnit(
+            this.fboTextures[DitherPipeline.PASS_PREPROCESSED],
+            0,
+        );
+        const ed = this.edgeDetectProg;
+        gl.useProgram(ed.program);
+        gl.uniform1i(gl.getUniformLocation(ed.program, "u_source"), 0);
+        gl.uniform2f(
+            gl.getUniformLocation(ed.program, "u_texelSize"),
+            1 / w,
+            1 / h,
+        );
+        gl.uniform1f(
+            gl.getUniformLocation(ed.program, "u_strength"),
+            params.edgeStrength,
+        );
+        this.drawQuad(ed, this.fbos[DitherPipeline.PASS_EDGES]);
+
+        // ── Pass 3: Jump Flood Algorithm ────────────────────────────
+
+        // 3a: Seed
+        this.bindTextureToUnit(this.fboTextures[DitherPipeline.PASS_EDGES], 0);
+        const seed = this.jfaSeedProg;
+        gl.useProgram(seed.program);
+        gl.uniform1i(gl.getUniformLocation(seed.program, "u_edges"), 0);
+        gl.uniform1f(gl.getUniformLocation(seed.program, "u_threshold"), 0.05);
+        this.drawQuad(seed, this.jfaFbos[0]);
+
+        // 3b: JFA steps (ping-pong)
+        const maxDim = Math.max(w, h);
+        let stepSize = Math.pow(2, Math.ceil(Math.log2(maxDim)) - 1);
+        let readIdx = 0;
+
+        while (stepSize >= 1) {
+            const writeIdx = 1 - readIdx;
+            this.bindTextureToUnit(this.jfaTextures[readIdx], 0);
+            const step = this.jfaStepProg;
+            gl.useProgram(step.program);
+            gl.uniform1i(gl.getUniformLocation(step.program, "u_jfa"), 0);
+            gl.uniform2f(
+                gl.getUniformLocation(step.program, "u_texelSize"),
+                1 / w,
+                1 / h,
+            );
+            gl.uniform1f(
+                gl.getUniformLocation(step.program, "u_stepSize"),
+                stepSize,
+            );
+            this.drawQuad(step, this.jfaFbos[writeIdx]);
+            readIdx = writeIdx;
+            stepSize = Math.floor(stepSize / 2);
+        }
+
+        // 3c: Resolve to contrast map
+        this.bindTextureToUnit(this.jfaTextures[readIdx], 0);
+        const res = this.jfaResolveProg;
+        gl.useProgram(res.program);
+        gl.uniform1i(gl.getUniformLocation(res.program, "u_jfa"), 0);
+        gl.uniform2f(gl.getUniformLocation(res.program, "u_resolution"), w, h);
+        gl.uniform1f(
+            gl.getUniformLocation(res.program, "u_dropOffRate"),
+            params.dropOffRate,
+        );
+        gl.uniform1i(
+            gl.getUniformLocation(res.program, "u_dropOffFunction"),
+            DROP_OFF_FN_INDEX[params.dropOffFunction],
+        );
+        this.drawQuad(res, this.fbos[DitherPipeline.PASS_CONTRAST_MAP]);
+
+        // ── Pass 4: Adaptive Dithering ──────────────────────────────
+        this.bindTextureToUnit(
+            this.fboTextures[DitherPipeline.PASS_PREPROCESSED],
+            0,
+        );
+        this.bindTextureToUnit(
+            this.fboTextures[DitherPipeline.PASS_CONTRAST_MAP],
+            1,
+        );
+        const ad = this.adaptiveDitherProg;
+        gl.useProgram(ad.program);
+        gl.uniform1i(gl.getUniformLocation(ad.program, "u_preprocessed"), 0);
+        gl.uniform1i(gl.getUniformLocation(ad.program, "u_contrastMap"), 1);
+        gl.uniform2f(gl.getUniformLocation(ad.program, "u_resolution"), w, h);
+        gl.uniform1i(
+            gl.getUniformLocation(ad.program, "u_maxLevels"),
+            params.maxDitherLevels,
+        );
+        gl.uniform1f(
+            gl.getUniformLocation(ad.program, "u_rangeLow"),
+            params.contrastRangeLow,
+        );
+        gl.uniform1f(
+            gl.getUniformLocation(ad.program, "u_rangeHigh"),
+            params.contrastRangeHigh,
+        );
+        this.drawQuad(ad, this.fbos[DitherPipeline.PASS_DITHERED]);
+    }
+
+    /** Display one of the pass results to the visible canvas. */
+    displayPass(
+        pass:
+            | "original"
+            | "preprocessed"
+            | "edges"
+            | "contrastMap"
+            | "dithered",
+    ) {
+        const gl = this.rawGl;
+        this.canvas.width = this.currentWidth;
+        this.canvas.height = this.currentHeight;
+
+        let tex: WebGLTexture;
+        switch (pass) {
+            case "original":
+                tex = this.sourceTexture;
+                break;
+            case "preprocessed":
+                tex = this.fboTextures[DitherPipeline.PASS_PREPROCESSED];
+                break;
+            case "edges":
+                tex = this.fboTextures[DitherPipeline.PASS_EDGES];
+                break;
+            case "contrastMap":
+                tex = this.fboTextures[DitherPipeline.PASS_CONTRAST_MAP];
+                break;
+            case "dithered":
+                tex = this.fboTextures[DitherPipeline.PASS_DITHERED];
+                break;
+        }
+
+        this.bindTextureToUnit(tex, 0);
+        const dp = this.displayProg;
+        gl.useProgram(dp.program);
+        gl.uniform1i(gl.getUniformLocation(dp.program, "u_source"), 0);
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.viewport(0, 0, this.currentWidth, this.currentHeight);
+        dp.use();
+        this.quadVao.bindVao();
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    destroy() {
+        const gl = this.rawGl;
+        for (const fbo of this.fbos) gl.deleteFramebuffer(fbo);
+        for (const tex of this.fboTextures) gl.deleteTexture(tex);
+        for (const fbo of this.jfaFbos) gl.deleteFramebuffer(fbo);
+        for (const tex of this.jfaTextures) gl.deleteTexture(tex);
+        gl.deleteTexture(this.sourceTexture);
+        this.glCtx.destroy();
+    }
+}

--- a/src/adaptive-dither/gpuPipeline.ts
+++ b/src/adaptive-dither/gpuPipeline.ts
@@ -180,18 +180,22 @@ const ADAPTIVE_DITHER_FRAG = glsl`#version 300 es
     uniform float u_rangeLow;
     uniform float u_rangeHigh;
 
-    // 8x8 Bayer threshold via recursive formula (no local arrays)
+    // 8x8 Bayer matrix (normalized to [0, 1))
     float bayer8(vec2 pos) {
         ivec2 p = ivec2(pos) & 7;
-        int v = 0;
-        for (int i = 0; i < 3; i++) {
-            int xi = (p.x >> i) & 1;
-            int yi = (p.y >> i) & 1;
-            // 2x2 base pattern: [[0,2],[3,1]]
-            int b = xi * 2 + yi * 3 - xi * yi * 4;
-            v += b << (2 * (2 - i));
-        }
-        return (float(v) + 0.5) / 64.0;
+        int idx = p.x + p.y * 8;
+        // Precomputed 8x8 Bayer matrix
+        int b8[64] = int[64](
+             0, 32,  8, 40,  2, 34, 10, 42,
+            48, 16, 56, 24, 50, 18, 58, 26,
+            12, 44,  4, 36, 14, 46,  6, 38,
+            60, 28, 52, 20, 62, 30, 54, 22,
+             3, 35, 11, 43,  1, 33,  9, 41,
+            51, 19, 59, 27, 49, 17, 57, 25,
+            15, 47,  7, 39, 13, 45,  5, 37,
+            63, 31, 55, 23, 61, 29, 53, 21
+        );
+        return (float(b8[idx]) + 0.5) / 64.0;
     }
 
     // Dither at a given block size using Bayer pattern

--- a/src/adaptive-dither/gpuPipeline.ts
+++ b/src/adaptive-dither/gpuPipeline.ts
@@ -180,22 +180,18 @@ const ADAPTIVE_DITHER_FRAG = glsl`#version 300 es
     uniform float u_rangeLow;
     uniform float u_rangeHigh;
 
-    // 8x8 Bayer matrix (normalized to [0, 1))
+    // 8x8 Bayer threshold via recursive formula (no local arrays)
     float bayer8(vec2 pos) {
         ivec2 p = ivec2(pos) & 7;
-        int idx = p.x + p.y * 8;
-        // Precomputed 8x8 Bayer matrix
-        int b8[64] = int[64](
-             0, 32,  8, 40,  2, 34, 10, 42,
-            48, 16, 56, 24, 50, 18, 58, 26,
-            12, 44,  4, 36, 14, 46,  6, 38,
-            60, 28, 52, 20, 62, 30, 54, 22,
-             3, 35, 11, 43,  1, 33,  9, 41,
-            51, 19, 59, 27, 49, 17, 57, 25,
-            15, 47,  7, 39, 13, 45,  5, 37,
-            63, 31, 55, 23, 61, 29, 53, 21
-        );
-        return (float(b8[idx]) + 0.5) / 64.0;
+        int v = 0;
+        for (int i = 0; i < 3; i++) {
+            int xi = (p.x >> i) & 1;
+            int yi = (p.y >> i) & 1;
+            // 2x2 base pattern: [[0,2],[3,1]]
+            int b = xi * 2 + yi * 3 - xi * yi * 4;
+            v += b << (2 * (2 - i));
+        }
+        return (float(v) + 0.5) / 64.0;
     }
 
     // Dither at a given block size using Bayer pattern

--- a/src/adaptive-dither/index.html
+++ b/src/adaptive-dither/index.html
@@ -6,9 +6,11 @@
         <link rel="stylesheet" href="../tailwind.css" />
         <style>
             html,
-            body {
+            body,
+            #root {
                 width: 100%;
                 height: 100%;
+                overflow: hidden;
             }
         </style>
     </head>

--- a/src/adaptive-dither/index.html
+++ b/src/adaptive-dither/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>adaptive dither</title>
+        <link rel="stylesheet" href="../tailwind.css" />
+        <style>
+            html,
+            body {
+                width: 100%;
+                height: 100%;
+            }
+        </style>
+    </head>
+    <body class="bg-stone-100 font-mono text-stone-800">
+        <div id="root"></div>
+        <script src="./adaptive-dither-main.tsx" type="module"></script>
+    </body>
+</html>

--- a/src/adaptive-dither/processing.ts
+++ b/src/adaptive-dither/processing.ts
@@ -16,9 +16,11 @@ export interface ProcessingParams {
     dropOffFunction: "linear" | "exponential" | "quadratic" | "sine";
 
     // Pass 4: Adaptive dithering
+    ditherPattern: "floyd-steinberg" | "atkinson" | "ordered" | "noise";
     maxDitherLevels: number;
     contrastRangeLow: number;
     contrastRangeHigh: number;
+    preserveBlocks: boolean;
 }
 
 export const DEFAULT_PARAMS: ProcessingParams = {
@@ -28,9 +30,11 @@ export const DEFAULT_PARAMS: ProcessingParams = {
     edgeStrength: 1,
     radius: 50,
     dropOffFunction: "exponential",
+    ditherPattern: "floyd-steinberg",
     maxDitherLevels: 5,
     contrastRangeLow: 0.1,
     contrastRangeHigh: 0.8,
+    preserveBlocks: false,
 };
 
 /**
@@ -124,9 +128,29 @@ export function detectEdges(
     return edges;
 }
 
+// prettier-ignore
+const BAYER_8X8 = [
+     0, 48, 12, 60,  3, 51, 15, 63,
+    32, 16, 44, 28, 35, 19, 47, 31,
+     8, 56,  4, 52, 11, 59,  7, 55,
+    40, 24, 36, 20, 43, 27, 39, 23,
+     2, 50, 14, 62,  1, 49, 13, 61,
+    34, 18, 46, 30, 33, 17, 45, 29,
+    10, 58,  6, 54,  9, 57,  5, 53,
+    42, 26, 38, 22, 41, 25, 37, 21,
+];
+const BAYER_NORM = BAYER_8X8.map((v) => (v + 0.5) / 64);
+
+/** Simple deterministic hash for noise dithering. */
+function hashNoise(x: number, y: number, seed: number): number {
+    let h = (seed * 374761393 + x * 668265263 + y * 2147483647) | 0;
+    h = Math.imul(h ^ (h >>> 13), 1274126177);
+    h = h ^ (h >>> 16);
+    return (h & 0x7fffffff) / 0x7fffffff;
+}
+
 /**
- * Floyd-Steinberg dithering on a grayscale buffer at a given block size.
- * blockSize=1 means pixel-level dithering, blockSize=2 means 2x2 blocks, etc.
+ * Dither a grayscale buffer at a given block size using the specified pattern.
  * Returns a Uint8Array of 0 or 255 values at the original resolution.
  */
 function ditherAtBlockSize(
@@ -134,6 +158,7 @@ function ditherAtBlockSize(
     width: number,
     height: number,
     blockSize: number,
+    pattern: ProcessingParams["ditherPattern"],
 ): Uint8Array {
     // Downsample by averaging blocks
     const bw = Math.ceil(width / blockSize);
@@ -158,23 +183,62 @@ function ditherAtBlockSize(
         }
     }
 
-    // Floyd-Steinberg on the blocked image
     const dithered = new Float32Array(blocked);
-    for (let y = 0; y < bh; y++) {
-        for (let x = 0; x < bw; x++) {
-            const idx = y * bw + x;
-            const old = dithered[idx];
-            const newVal = old >= 0.5 ? 1 : 0;
-            dithered[idx] = newVal;
-            const err = old - newVal;
 
-            if (x + 1 < bw) dithered[idx + 1] += (err * 7) / 16;
-            if (y + 1 < bh) {
-                if (x - 1 >= 0)
-                    dithered[(y + 1) * bw + (x - 1)] += (err * 3) / 16;
-                dithered[(y + 1) * bw + x] += (err * 5) / 16;
-                if (x + 1 < bw)
-                    dithered[(y + 1) * bw + (x + 1)] += (err * 1) / 16;
+    if (pattern === "floyd-steinberg") {
+        for (let y = 0; y < bh; y++) {
+            for (let x = 0; x < bw; x++) {
+                const idx = y * bw + x;
+                const old = dithered[idx];
+                const newVal = old >= 0.5 ? 1 : 0;
+                dithered[idx] = newVal;
+                const err = old - newVal;
+
+                if (x + 1 < bw) dithered[idx + 1] += (err * 7) / 16;
+                if (y + 1 < bh) {
+                    if (x - 1 >= 0)
+                        dithered[(y + 1) * bw + (x - 1)] += (err * 3) / 16;
+                    dithered[(y + 1) * bw + x] += (err * 5) / 16;
+                    if (x + 1 < bw)
+                        dithered[(y + 1) * bw + (x + 1)] += (err * 1) / 16;
+                }
+            }
+        }
+    } else if (pattern === "atkinson") {
+        for (let y = 0; y < bh; y++) {
+            for (let x = 0; x < bw; x++) {
+                const idx = y * bw + x;
+                const old = dithered[idx];
+                const newVal = old >= 0.5 ? 1 : 0;
+                dithered[idx] = newVal;
+                const err = (old - newVal) / 8;
+
+                if (x + 1 < bw) dithered[idx + 1] += err;
+                if (x + 2 < bw) dithered[idx + 2] += err;
+                if (y + 1 < bh) {
+                    if (x - 1 >= 0) dithered[(y + 1) * bw + (x - 1)] += err;
+                    dithered[(y + 1) * bw + x] += err;
+                    if (x + 1 < bw) dithered[(y + 1) * bw + (x + 1)] += err;
+                }
+                if (y + 2 < bh) {
+                    dithered[(y + 2) * bw + x] += err;
+                }
+            }
+        }
+    } else if (pattern === "ordered") {
+        for (let y = 0; y < bh; y++) {
+            for (let x = 0; x < bw; x++) {
+                const threshold = BAYER_NORM[(y & 7) * 8 + (x & 7)];
+                dithered[y * bw + x] = blocked[y * bw + x] > threshold ? 1 : 0;
+            }
+        }
+    } else {
+        // noise
+        const seed = blockSize * 31337;
+        for (let y = 0; y < bh; y++) {
+            for (let x = 0; x < bw; x++) {
+                const threshold = hashNoise(x, y, seed);
+                dithered[y * bw + x] = blocked[y * bw + x] > threshold ? 1 : 0;
             }
         }
     }
@@ -199,6 +263,77 @@ function ditherAtBlockSize(
  * High contrast areas get fine (1:1) dithering.
  * Low contrast areas get coarse (large block) dithering.
  */
+/** Compute per-pixel level index from contrast map value. */
+function contrastToLevel(
+    c: number,
+    rangeLow: number,
+    rangeHigh: number,
+    maxLevels: number,
+): number {
+    let t: number;
+    if (c >= rangeHigh) {
+        t = 0;
+    } else if (c <= rangeLow) {
+        t = 1;
+    } else {
+        t = 1 - (c - rangeLow) / (rangeHigh - rangeLow);
+    }
+    return Math.min(Math.round(t * (maxLevels - 1)), maxLevels - 1);
+}
+
+/**
+ * Block-preserving compositing: iterate coarse-to-fine, overwriting entire
+ * blocks atomically when any pixel in the block requests that level or finer.
+ */
+function compositeBlocks(
+    levels: Uint8Array[],
+    levelMap: Uint8Array,
+    width: number,
+    height: number,
+    maxLevels: number,
+): Uint8Array {
+    // Start with the coarsest level
+    const output = new Uint8Array(levels[maxLevels - 1]);
+
+    // Iterate from second-coarsest down to finest
+    for (let level = maxLevels - 2; level >= 0; level--) {
+        const blockSize = 1 << level;
+        const bw = Math.ceil(width / blockSize);
+        const bh = Math.ceil(height / blockSize);
+
+        for (let by = 0; by < bh; by++) {
+            for (let bx = 0; bx < bw; bx++) {
+                const x0 = bx * blockSize;
+                const y0 = by * blockSize;
+                const x1 = Math.min(x0 + blockSize, width);
+                const y1 = Math.min(y0 + blockSize, height);
+
+                // Check if any pixel in this block needs this level or finer
+                let needsLevel = false;
+                for (let y = y0; y < y1 && !needsLevel; y++) {
+                    for (let x = x0; x < x1 && !needsLevel; x++) {
+                        if (levelMap[y * width + x] <= level) {
+                            needsLevel = true;
+                        }
+                    }
+                }
+
+                if (needsLevel) {
+                    const src = levels[level];
+                    for (let y = y0; y < y1; y++) {
+                        for (let x = x0; x < x1; x++) {
+                            const idx = y * width + x;
+                            output[idx] = src[idx];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return output;
+}
+
 export function adaptiveDither(
     preprocessed: Float32Array,
     contrastMap: Float32Array,
@@ -207,33 +342,47 @@ export function adaptiveDither(
     maxLevels: number,
     rangeLow: number,
     rangeHigh: number,
+    ditherPattern: ProcessingParams["ditherPattern"],
+    preserveBlocks: boolean,
 ): Uint8Array {
     // Generate dithered versions at each block size level
     const levels: Uint8Array[] = [];
     for (let i = 0; i < maxLevels; i++) {
         const blockSize = 1 << i; // 1, 2, 4, 8, 16, ...
-        levels.push(ditherAtBlockSize(preprocessed, width, height, blockSize));
+        levels.push(
+            ditherAtBlockSize(
+                preprocessed,
+                width,
+                height,
+                blockSize,
+                ditherPattern,
+            ),
+        );
     }
 
-    // Blend based on contrast map
+    if (preserveBlocks) {
+        const levelMap = new Uint8Array(width * height);
+        for (let i = 0; i < width * height; i++) {
+            levelMap[i] = contrastToLevel(
+                contrastMap[i],
+                rangeLow,
+                rangeHigh,
+                maxLevels,
+            );
+        }
+        return compositeBlocks(levels, levelMap, width, height, maxLevels);
+    }
+
+    // Per-pixel blending (original behavior)
     const output = new Uint8Array(width * height);
     for (let i = 0; i < width * height; i++) {
-        const c = contrastMap[i];
-        // Map contrast value to a level index
-        // High contrast (>= rangeHigh) -> level 0 (finest)
-        // Low contrast (<= rangeLow) -> level maxLevels-1 (coarsest)
-        let t: number;
-        if (c >= rangeHigh) {
-            t = 0;
-        } else if (c <= rangeLow) {
-            t = 1;
-        } else {
-            t = 1 - (c - rangeLow) / (rangeHigh - rangeLow);
-        }
-
-        const levelFloat = t * (maxLevels - 1);
-        const levelIdx = Math.round(levelFloat);
-        output[i] = levels[Math.min(levelIdx, maxLevels - 1)][i];
+        const levelIdx = contrastToLevel(
+            contrastMap[i],
+            rangeLow,
+            rangeHigh,
+            maxLevels,
+        );
+        output[i] = levels[levelIdx][i];
     }
 
     return output;
@@ -266,6 +415,8 @@ export async function adaptiveDitherAsync(
     maxLevels: number,
     rangeLow: number,
     rangeHigh: number,
+    ditherPattern: ProcessingParams["ditherPattern"],
+    preserveBlocks: boolean,
     { signal, onProgress }: AsyncPassOptions,
 ): Promise<Uint8Array> {
     // Phase 1: Generate dithered versions (50% of progress)
@@ -273,30 +424,65 @@ export async function adaptiveDitherAsync(
     for (let i = 0; i < maxLevels; i++) {
         if (signal.aborted) throw new DOMException("Aborted", "AbortError");
         const blockSize = 1 << i;
-        levels.push(ditherAtBlockSize(preprocessed, width, height, blockSize));
+        levels.push(
+            ditherAtBlockSize(
+                preprocessed,
+                width,
+                height,
+                blockSize,
+                ditherPattern,
+            ),
+        );
         onProgress(((i + 1) / maxLevels) * 0.5);
         await frame();
     }
 
-    // Phase 2: Blend based on contrast map (remaining 50%)
-    const output = new Uint8Array(width * height);
+    // Phase 2: Composite / blend (remaining 50%)
     const totalPixels = width * height;
+
+    if (preserveBlocks) {
+        // Build per-pixel level map
+        const levelMap = new Uint8Array(totalPixels);
+        let lastYield = performance.now();
+        for (let i = 0; i < totalPixels; i++) {
+            levelMap[i] = contrastToLevel(
+                contrastMap[i],
+                rangeLow,
+                rangeHigh,
+                maxLevels,
+            );
+            if (i % 50000 === 0) {
+                if (signal.aborted)
+                    throw new DOMException("Aborted", "AbortError");
+                onProgress(0.5 + (i / totalPixels) * 0.25);
+                lastYield = await yieldIfNeeded(lastYield);
+            }
+        }
+
+        // Block compositing
+        const output = compositeBlocks(
+            levels,
+            levelMap,
+            width,
+            height,
+            maxLevels,
+        );
+        onProgress(1);
+        return output;
+    }
+
+    // Per-pixel blending (original behavior)
+    const output = new Uint8Array(totalPixels);
     let lastYield = performance.now();
 
     for (let i = 0; i < totalPixels; i++) {
-        const c = contrastMap[i];
-        let t: number;
-        if (c >= rangeHigh) {
-            t = 0;
-        } else if (c <= rangeLow) {
-            t = 1;
-        } else {
-            t = 1 - (c - rangeLow) / (rangeHigh - rangeLow);
-        }
-
-        const levelFloat = t * (maxLevels - 1);
-        const levelIdx = Math.round(levelFloat);
-        output[i] = levels[Math.min(levelIdx, maxLevels - 1)][i];
+        const levelIdx = contrastToLevel(
+            contrastMap[i],
+            rangeLow,
+            rangeHigh,
+            maxLevels,
+        );
+        output[i] = levels[levelIdx][i];
 
         if (i % 50000 === 0) {
             if (signal.aborted) throw new DOMException("Aborted", "AbortError");

--- a/src/adaptive-dither/processing.ts
+++ b/src/adaptive-dither/processing.ts
@@ -134,13 +134,11 @@ function getDropOffFn(
         case "exponential":
             return (d, r) => Math.exp(-d * r);
         case "quadratic":
-            return (d, r) => Math.max(0, 1 - (d * r) * (d * r));
+            return (d, r) => Math.max(0, 1 - d * r * (d * r));
         case "sine":
             return (d, r) => {
                 const v = d * r;
-                return v >= 1 ?
-                        0
-                    :   Math.cos((v * Math.PI) / 2);
+                return v >= 1 ? 0 : Math.cos((v * Math.PI) / 2);
             };
     }
 }
@@ -270,11 +268,13 @@ function ditherAtBlockSize(
             dithered[idx] = newVal;
             const err = old - newVal;
 
-            if (x + 1 < bw) dithered[idx + 1] += err * 7 / 16;
+            if (x + 1 < bw) dithered[idx + 1] += (err * 7) / 16;
             if (y + 1 < bh) {
-                if (x - 1 >= 0) dithered[(y + 1) * bw + (x - 1)] += err * 3 / 16;
-                dithered[(y + 1) * bw + x] += err * 5 / 16;
-                if (x + 1 < bw) dithered[(y + 1) * bw + (x + 1)] += err * 1 / 16;
+                if (x - 1 >= 0)
+                    dithered[(y + 1) * bw + (x - 1)] += (err * 3) / 16;
+                dithered[(y + 1) * bw + x] += (err * 5) / 16;
+                if (x + 1 < bw)
+                    dithered[(y + 1) * bw + (x + 1)] += (err * 1) / 16;
             }
         }
     }

--- a/src/adaptive-dither/processing.ts
+++ b/src/adaptive-dither/processing.ts
@@ -1,0 +1,386 @@
+/** Image processing pipeline for adaptive dithering */
+
+export interface ProcessingParams {
+    // Pass 1: Preprocessing
+    scale: number;
+    brightness: number;
+    contrast: number;
+
+    // Pass 2: Edge detection
+    edgeStrength: number;
+
+    // Pass 3: Contrast map
+    dropOffRate: number;
+    dropOffFunction: "linear" | "exponential" | "quadratic" | "sine";
+
+    // Pass 4: Adaptive dithering
+    maxDitherLevels: number;
+    contrastRangeLow: number;
+    contrastRangeHigh: number;
+}
+
+export const DEFAULT_PARAMS: ProcessingParams = {
+    scale: 1,
+    brightness: 0,
+    contrast: 0,
+    edgeStrength: 1,
+    dropOffRate: 0.05,
+    dropOffFunction: "exponential",
+    maxDitherLevels: 5,
+    contrastRangeLow: 0.1,
+    contrastRangeHigh: 0.8,
+};
+
+/**
+ * Get grayscale pixel data from an image, scaled to the given dimensions.
+ * Returns a Float32Array of values in [0, 1].
+ */
+export function getScaledGrayscale(
+    image: HTMLImageElement,
+    width: number,
+    height: number,
+): Float32Array {
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d")!;
+    ctx.drawImage(image, 0, 0, width, height);
+    const imageData = ctx.getImageData(0, 0, width, height);
+    const pixels = imageData.data;
+    const gray = new Float32Array(width * height);
+    for (let i = 0; i < gray.length; i++) {
+        const r = pixels[i * 4];
+        const g = pixels[i * 4 + 1];
+        const b = pixels[i * 4 + 2];
+        gray[i] = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    }
+    return gray;
+}
+
+/**
+ * Pass 1: Apply brightness and contrast adjustments.
+ * brightness in [-1, 1], contrast in [-1, 1].
+ */
+export function applyBrightnessContrast(
+    gray: Float32Array,
+    brightness: number,
+    contrast: number,
+): Float32Array {
+    const out = new Float32Array(gray.length);
+    // contrast factor: maps [-1, 1] to a multiplier
+    const factor = contrast >= 0 ? 1 + contrast * 3 : 1 + contrast;
+    for (let i = 0; i < gray.length; i++) {
+        let v = gray[i];
+        // apply brightness
+        v += brightness;
+        // apply contrast around midpoint
+        v = (v - 0.5) * factor + 0.5;
+        out[i] = Math.max(0, Math.min(1, v));
+    }
+    return out;
+}
+
+/**
+ * Pass 2: Sobel edge detection.
+ * Returns a Float32Array of edge magnitudes normalized to [0, 1].
+ */
+export function detectEdges(
+    gray: Float32Array,
+    width: number,
+    height: number,
+    strength: number,
+): Float32Array {
+    const edges = new Float32Array(width * height);
+    let maxVal = 0;
+
+    for (let y = 1; y < height - 1; y++) {
+        for (let x = 1; x < width - 1; x++) {
+            const tl = gray[(y - 1) * width + (x - 1)];
+            const tc = gray[(y - 1) * width + x];
+            const tr = gray[(y - 1) * width + (x + 1)];
+            const ml = gray[y * width + (x - 1)];
+            const mr = gray[y * width + (x + 1)];
+            const bl = gray[(y + 1) * width + (x - 1)];
+            const bc = gray[(y + 1) * width + x];
+            const br = gray[(y + 1) * width + (x + 1)];
+
+            const gx = -tl - 2 * ml - bl + tr + 2 * mr + br;
+            const gy = -tl - 2 * tc - tr + bl + 2 * bc + br;
+            const mag = Math.sqrt(gx * gx + gy * gy) * strength;
+            edges[y * width + x] = mag;
+            if (mag > maxVal) maxVal = mag;
+        }
+    }
+
+    // Normalize
+    if (maxVal > 0) {
+        for (let i = 0; i < edges.length; i++) {
+            edges[i] = Math.min(1, edges[i] / maxVal);
+        }
+    }
+
+    return edges;
+}
+
+/**
+ * Drop-off functions for the contrast map propagation.
+ */
+function getDropOffFn(
+    type: ProcessingParams["dropOffFunction"],
+): (distance: number, rate: number) => number {
+    switch (type) {
+        case "linear":
+            return (d, r) => Math.max(0, 1 - d * r);
+        case "exponential":
+            return (d, r) => Math.exp(-d * r);
+        case "quadratic":
+            return (d, r) => Math.max(0, 1 - (d * r) * (d * r));
+        case "sine":
+            return (d, r) => {
+                const v = d * r;
+                return v >= 1 ?
+                        0
+                    :   Math.cos((v * Math.PI) / 2);
+            };
+    }
+}
+
+/**
+ * Pass 3: Build contrast map by propagating edge values outward.
+ * This works like a distance field: high-contrast pixels seed the map,
+ * and their influence drops off with distance according to the chosen function.
+ *
+ * Uses a BFS-like flood fill from high-edge pixels.
+ */
+export function buildContrastMap(
+    edges: Float32Array,
+    width: number,
+    height: number,
+    dropOffRate: number,
+    dropOffFunction: ProcessingParams["dropOffFunction"],
+): Float32Array {
+    const contrastMap = new Float32Array(width * height);
+    const dropOff = getDropOffFn(dropOffFunction);
+
+    // Distance from nearest significant edge pixel
+    const dist = new Float32Array(width * height).fill(Infinity);
+
+    // Edge value of the source pixel that influenced each cell
+    const sourceEdge = new Float32Array(width * height);
+
+    // BFS queue: [index, distance, sourceEdgeValue]
+    const queue: [number, number, number][] = [];
+
+    // Seed with all pixels that have non-trivial edge values
+    const threshold = 0.05;
+    for (let i = 0; i < edges.length; i++) {
+        if (edges[i] > threshold) {
+            dist[i] = 0;
+            sourceEdge[i] = edges[i];
+            contrastMap[i] = edges[i];
+            queue.push([i, 0, edges[i]]);
+        }
+    }
+
+    // Sort by edge value descending so strongest edges propagate first
+    queue.sort((a, b) => b[2] - a[2]);
+
+    const dx = [-1, 1, 0, 0];
+    const dy = [0, 0, -1, 1];
+
+    let head = 0;
+    while (head < queue.length) {
+        const [idx, d, srcEdge] = queue[head++];
+        const x = idx % width;
+        const y = (idx - x) / width;
+
+        for (let dir = 0; dir < 4; dir++) {
+            const nx = x + dx[dir];
+            const ny = y + dy[dir];
+            if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+
+            const nIdx = ny * width + nx;
+            const newDist = d + 1;
+            const newVal = srcEdge * dropOff(newDist, dropOffRate);
+
+            if (newVal > contrastMap[nIdx]) {
+                contrastMap[nIdx] = newVal;
+                dist[nIdx] = newDist;
+                sourceEdge[nIdx] = srcEdge;
+                queue.push([nIdx, newDist, srcEdge]);
+            }
+        }
+    }
+
+    // Normalize the contrast map to [0, 1]
+    let maxVal = 0;
+    for (const v of contrastMap) {
+        if (v > maxVal) maxVal = v;
+    }
+    if (maxVal > 0) {
+        for (let i = 0; i < contrastMap.length; i++) {
+            contrastMap[i] /= maxVal;
+        }
+    }
+
+    return contrastMap;
+}
+
+/**
+ * Floyd-Steinberg dithering on a grayscale buffer at a given block size.
+ * blockSize=1 means pixel-level dithering, blockSize=2 means 2x2 blocks, etc.
+ * Returns a Uint8Array of 0 or 255 values at the original resolution.
+ */
+function ditherAtBlockSize(
+    gray: Float32Array,
+    width: number,
+    height: number,
+    blockSize: number,
+): Uint8Array {
+    // Downsample by averaging blocks
+    const bw = Math.ceil(width / blockSize);
+    const bh = Math.ceil(height / blockSize);
+    const blocked = new Float32Array(bw * bh);
+
+    for (let by = 0; by < bh; by++) {
+        for (let bx = 0; bx < bw; bx++) {
+            let sum = 0;
+            let count = 0;
+            for (let dy = 0; dy < blockSize; dy++) {
+                for (let dx = 0; dx < blockSize; dx++) {
+                    const sx = bx * blockSize + dx;
+                    const sy = by * blockSize + dy;
+                    if (sx < width && sy < height) {
+                        sum += gray[sy * width + sx];
+                        count++;
+                    }
+                }
+            }
+            blocked[by * bw + bx] = sum / count;
+        }
+    }
+
+    // Floyd-Steinberg on the blocked image
+    const dithered = new Float32Array(blocked);
+    for (let y = 0; y < bh; y++) {
+        for (let x = 0; x < bw; x++) {
+            const idx = y * bw + x;
+            const old = dithered[idx];
+            const newVal = old >= 0.5 ? 1 : 0;
+            dithered[idx] = newVal;
+            const err = old - newVal;
+
+            if (x + 1 < bw) dithered[idx + 1] += err * 7 / 16;
+            if (y + 1 < bh) {
+                if (x - 1 >= 0) dithered[(y + 1) * bw + (x - 1)] += err * 3 / 16;
+                dithered[(y + 1) * bw + x] += err * 5 / 16;
+                if (x + 1 < bw) dithered[(y + 1) * bw + (x + 1)] += err * 1 / 16;
+            }
+        }
+    }
+
+    // Upscale back to original resolution
+    const result = new Uint8Array(width * height);
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            const bx = Math.floor(x / blockSize);
+            const by = Math.floor(y / blockSize);
+            result[y * width + x] = dithered[by * bw + bx] >= 0.5 ? 255 : 0;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Pass 4: Adaptive multi-resolution dithering.
+ *
+ * Uses the contrast map to select dithering resolution per region.
+ * High contrast areas get fine (1:1) dithering.
+ * Low contrast areas get coarse (large block) dithering.
+ */
+export function adaptiveDither(
+    preprocessed: Float32Array,
+    contrastMap: Float32Array,
+    width: number,
+    height: number,
+    maxLevels: number,
+    rangeLow: number,
+    rangeHigh: number,
+): Uint8Array {
+    // Generate dithered versions at each block size level
+    const levels: Uint8Array[] = [];
+    for (let i = 0; i < maxLevels; i++) {
+        const blockSize = 1 << i; // 1, 2, 4, 8, 16, ...
+        levels.push(ditherAtBlockSize(preprocessed, width, height, blockSize));
+    }
+
+    // Blend based on contrast map
+    const output = new Uint8Array(width * height);
+    for (let i = 0; i < width * height; i++) {
+        const c = contrastMap[i];
+        // Map contrast value to a level index
+        // High contrast (>= rangeHigh) -> level 0 (finest)
+        // Low contrast (<= rangeLow) -> level maxLevels-1 (coarsest)
+        let t: number;
+        if (c >= rangeHigh) {
+            t = 0;
+        } else if (c <= rangeLow) {
+            t = 1;
+        } else {
+            t = 1 - (c - rangeLow) / (rangeHigh - rangeLow);
+        }
+
+        const levelFloat = t * (maxLevels - 1);
+        const levelIdx = Math.round(levelFloat);
+        output[i] = levels[Math.min(levelIdx, maxLevels - 1)][i];
+    }
+
+    return output;
+}
+
+/**
+ * Render a Float32Array [0,1] as grayscale onto a canvas.
+ */
+export function renderGrayscale(
+    data: Float32Array,
+    width: number,
+    height: number,
+    canvas: HTMLCanvasElement,
+): void {
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d")!;
+    const imageData = ctx.createImageData(width, height);
+    for (let i = 0; i < data.length; i++) {
+        const v = Math.max(0, Math.min(255, Math.round(data[i] * 255)));
+        imageData.data[i * 4] = v;
+        imageData.data[i * 4 + 1] = v;
+        imageData.data[i * 4 + 2] = v;
+        imageData.data[i * 4 + 3] = 255;
+    }
+    ctx.putImageData(imageData, 0, 0);
+}
+
+/**
+ * Render a Uint8Array (0 or 255) as black/white onto a canvas.
+ */
+export function renderBinary(
+    data: Uint8Array,
+    width: number,
+    height: number,
+    canvas: HTMLCanvasElement,
+): void {
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d")!;
+    const imageData = ctx.createImageData(width, height);
+    for (let i = 0; i < data.length; i++) {
+        const v = data[i];
+        imageData.data[i * 4] = v;
+        imageData.data[i * 4 + 1] = v;
+        imageData.data[i * 4 + 2] = v;
+        imageData.data[i * 4 + 3] = 255;
+    }
+    ctx.putImageData(imageData, 0, 0);
+}

--- a/src/adaptive-dither/processing.ts
+++ b/src/adaptive-dither/processing.ts
@@ -1,5 +1,7 @@
 /** Image processing pipeline for adaptive dithering */
 
+import { frame } from "@/lib/utils";
+
 export interface ProcessingParams {
     // Pass 1: Preprocessing
     scale: number;
@@ -336,6 +338,166 @@ export function adaptiveDither(
         output[i] = levels[Math.min(levelIdx, maxLevels - 1)][i];
     }
 
+    return output;
+}
+
+// ── Async batched CPU passes ─────────────────────────────────────────
+
+interface AsyncPassOptions {
+    signal: AbortSignal;
+    onProgress: (progress: number) => void;
+}
+
+async function yieldIfNeeded(start: number): Promise<number> {
+    if (performance.now() - start > 10) {
+        await frame();
+        return performance.now();
+    }
+    return start;
+}
+
+/**
+ * Async version of buildContrastMap that yields to the browser and supports
+ * cancellation via AbortSignal. Reports progress as head / queue.length.
+ */
+export async function buildContrastMapAsync(
+    edges: Float32Array,
+    width: number,
+    height: number,
+    dropOffRate: number,
+    dropOffFunction: ProcessingParams["dropOffFunction"],
+    { signal, onProgress }: AsyncPassOptions,
+): Promise<Float32Array> {
+    const totalPixels = width * height;
+    const contrastMap = new Float32Array(totalPixels);
+    const dropOff = getDropOffFn(dropOffFunction);
+
+    // Track which pixels have been finalized to prevent unbounded queue growth.
+    // Without this, pixels get re-enqueued every time a better value arrives,
+    // causing the queue to explode to tens of millions of entries.
+    const processed = new Uint8Array(totalPixels);
+
+    const queue: [number, number, number][] = [];
+
+    const threshold = 0.05;
+    for (let i = 0; i < edges.length; i++) {
+        if (edges[i] > threshold) {
+            contrastMap[i] = edges[i];
+            queue.push([i, 0, edges[i]]);
+        }
+    }
+
+    // Sort by edge value descending so strongest edges propagate first.
+    // Since we process in order and mark pixels done, strong sources win.
+    queue.sort((a, b) => b[2] - a[2]);
+
+    const dx = [-1, 1, 0, 0];
+    const dy = [0, 0, -1, 1];
+
+    let head = 0;
+    let processedCount = 0;
+    let lastYield = performance.now();
+    while (head < queue.length) {
+        const [idx, d, srcEdge] = queue[head++];
+
+        if (processed[idx]) continue;
+        processed[idx] = 1;
+        processedCount++;
+
+        const x = idx % width;
+        const y = (idx - x) / width;
+
+        for (let dir = 0; dir < 4; dir++) {
+            const nx = x + dx[dir];
+            const ny = y + dy[dir];
+            if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+
+            const nIdx = ny * width + nx;
+            if (processed[nIdx]) continue;
+
+            const newDist = d + 1;
+            const newVal = srcEdge * dropOff(newDist, dropOffRate);
+
+            if (newVal > contrastMap[nIdx]) {
+                contrastMap[nIdx] = newVal;
+                queue.push([nIdx, newDist, srcEdge]);
+            }
+        }
+
+        if (processedCount % 10000 === 0) {
+            if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+            onProgress(processedCount / totalPixels);
+            lastYield = await yieldIfNeeded(lastYield);
+        }
+    }
+
+    // Normalize
+    let maxVal = 0;
+    for (const v of contrastMap) {
+        if (v > maxVal) maxVal = v;
+    }
+    if (maxVal > 0) {
+        for (let i = 0; i < contrastMap.length; i++) {
+            contrastMap[i] /= maxVal;
+        }
+    }
+
+    onProgress(1);
+    return contrastMap;
+}
+
+/**
+ * Async version of adaptiveDither that yields to the browser and supports
+ * cancellation. Reports progress across dither level generation and blending.
+ */
+export async function adaptiveDitherAsync(
+    preprocessed: Float32Array,
+    contrastMap: Float32Array,
+    width: number,
+    height: number,
+    maxLevels: number,
+    rangeLow: number,
+    rangeHigh: number,
+    { signal, onProgress }: AsyncPassOptions,
+): Promise<Uint8Array> {
+    // Phase 1: Generate dithered versions (50% of progress)
+    const levels: Uint8Array[] = [];
+    for (let i = 0; i < maxLevels; i++) {
+        if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+        const blockSize = 1 << i;
+        levels.push(ditherAtBlockSize(preprocessed, width, height, blockSize));
+        onProgress(((i + 1) / maxLevels) * 0.5);
+        await frame();
+    }
+
+    // Phase 2: Blend based on contrast map (remaining 50%)
+    const output = new Uint8Array(width * height);
+    const totalPixels = width * height;
+    let lastYield = performance.now();
+
+    for (let i = 0; i < totalPixels; i++) {
+        const c = contrastMap[i];
+        let t: number;
+        if (c >= rangeHigh) {
+            t = 0;
+        } else if (c <= rangeLow) {
+            t = 1;
+        } else {
+            t = 1 - (c - rangeLow) / (rangeHigh - rangeLow);
+        }
+
+        const levelFloat = t * (maxLevels - 1);
+        const levelIdx = Math.round(levelFloat);
+        output[i] = levels[Math.min(levelIdx, maxLevels - 1)][i];
+
+        if (i % 50000 === 0) {
+            if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+            onProgress(0.5 + (i / totalPixels) * 0.5);
+            lastYield = await yieldIfNeeded(lastYield);
+        }
+    }
+
+    onProgress(1);
     return output;
 }
 

--- a/src/adaptive-dither/processing.ts
+++ b/src/adaptive-dither/processing.ts
@@ -11,8 +11,8 @@ export interface ProcessingParams {
     // Pass 2: Edge detection
     edgeStrength: number;
 
-    // Pass 3: Contrast map
-    dropOffRate: number;
+    // Pass 3: Contrast map (GPU JFA)
+    radius: number;
     dropOffFunction: "linear" | "exponential" | "quadratic" | "sine";
 
     // Pass 4: Adaptive dithering
@@ -26,7 +26,7 @@ export const DEFAULT_PARAMS: ProcessingParams = {
     brightness: 0,
     contrast: 0,
     edgeStrength: 1,
-    dropOffRate: 0.05,
+    radius: 50,
     dropOffFunction: "exponential",
     maxDitherLevels: 5,
     contrastRangeLow: 0.1,
@@ -122,108 +122,6 @@ export function detectEdges(
     }
 
     return edges;
-}
-
-/**
- * Drop-off functions for the contrast map propagation.
- */
-function getDropOffFn(
-    type: ProcessingParams["dropOffFunction"],
-): (distance: number, rate: number) => number {
-    switch (type) {
-        case "linear":
-            return (d, r) => Math.max(0, 1 - d * r);
-        case "exponential":
-            return (d, r) => Math.exp(-d * r);
-        case "quadratic":
-            return (d, r) => Math.max(0, 1 - d * r * (d * r));
-        case "sine":
-            return (d, r) => {
-                const v = d * r;
-                return v >= 1 ? 0 : Math.cos((v * Math.PI) / 2);
-            };
-    }
-}
-
-/**
- * Pass 3: Build contrast map by propagating edge values outward.
- * This works like a distance field: high-contrast pixels seed the map,
- * and their influence drops off with distance according to the chosen function.
- *
- * Uses a BFS-like flood fill from high-edge pixels.
- */
-export function buildContrastMap(
-    edges: Float32Array,
-    width: number,
-    height: number,
-    dropOffRate: number,
-    dropOffFunction: ProcessingParams["dropOffFunction"],
-): Float32Array {
-    const contrastMap = new Float32Array(width * height);
-    const dropOff = getDropOffFn(dropOffFunction);
-
-    // Distance from nearest significant edge pixel
-    const dist = new Float32Array(width * height).fill(Infinity);
-
-    // Edge value of the source pixel that influenced each cell
-    const sourceEdge = new Float32Array(width * height);
-
-    // BFS queue: [index, distance, sourceEdgeValue]
-    const queue: [number, number, number][] = [];
-
-    // Seed with all pixels that have non-trivial edge values
-    const threshold = 0.05;
-    for (let i = 0; i < edges.length; i++) {
-        if (edges[i] > threshold) {
-            dist[i] = 0;
-            sourceEdge[i] = edges[i];
-            contrastMap[i] = edges[i];
-            queue.push([i, 0, edges[i]]);
-        }
-    }
-
-    // Sort by edge value descending so strongest edges propagate first
-    queue.sort((a, b) => b[2] - a[2]);
-
-    const dx = [-1, 1, 0, 0];
-    const dy = [0, 0, -1, 1];
-
-    let head = 0;
-    while (head < queue.length) {
-        const [idx, d, srcEdge] = queue[head++];
-        const x = idx % width;
-        const y = (idx - x) / width;
-
-        for (let dir = 0; dir < 4; dir++) {
-            const nx = x + dx[dir];
-            const ny = y + dy[dir];
-            if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
-
-            const nIdx = ny * width + nx;
-            const newDist = d + 1;
-            const newVal = srcEdge * dropOff(newDist, dropOffRate);
-
-            if (newVal > contrastMap[nIdx]) {
-                contrastMap[nIdx] = newVal;
-                dist[nIdx] = newDist;
-                sourceEdge[nIdx] = srcEdge;
-                queue.push([nIdx, newDist, srcEdge]);
-            }
-        }
-    }
-
-    // Normalize the contrast map to [0, 1]
-    let maxVal = 0;
-    for (const v of contrastMap) {
-        if (v > maxVal) maxVal = v;
-    }
-    if (maxVal > 0) {
-        for (let i = 0; i < contrastMap.length; i++) {
-            contrastMap[i] /= maxVal;
-        }
-    }
-
-    return contrastMap;
 }
 
 /**
@@ -354,96 +252,6 @@ async function yieldIfNeeded(start: number): Promise<number> {
         return performance.now();
     }
     return start;
-}
-
-/**
- * Async version of buildContrastMap that yields to the browser and supports
- * cancellation via AbortSignal. Reports progress as head / queue.length.
- */
-export async function buildContrastMapAsync(
-    edges: Float32Array,
-    width: number,
-    height: number,
-    dropOffRate: number,
-    dropOffFunction: ProcessingParams["dropOffFunction"],
-    { signal, onProgress }: AsyncPassOptions,
-): Promise<Float32Array> {
-    const totalPixels = width * height;
-    const contrastMap = new Float32Array(totalPixels);
-    const dropOff = getDropOffFn(dropOffFunction);
-
-    // Track which pixels have been finalized to prevent unbounded queue growth.
-    // Without this, pixels get re-enqueued every time a better value arrives,
-    // causing the queue to explode to tens of millions of entries.
-    const processed = new Uint8Array(totalPixels);
-
-    const queue: [number, number, number][] = [];
-
-    const threshold = 0.05;
-    for (let i = 0; i < edges.length; i++) {
-        if (edges[i] > threshold) {
-            contrastMap[i] = edges[i];
-            queue.push([i, 0, edges[i]]);
-        }
-    }
-
-    // Sort by edge value descending so strongest edges propagate first.
-    // Since we process in order and mark pixels done, strong sources win.
-    queue.sort((a, b) => b[2] - a[2]);
-
-    const dx = [-1, 1, 0, 0];
-    const dy = [0, 0, -1, 1];
-
-    let head = 0;
-    let processedCount = 0;
-    let lastYield = performance.now();
-    while (head < queue.length) {
-        const [idx, d, srcEdge] = queue[head++];
-
-        if (processed[idx]) continue;
-        processed[idx] = 1;
-        processedCount++;
-
-        const x = idx % width;
-        const y = (idx - x) / width;
-
-        for (let dir = 0; dir < 4; dir++) {
-            const nx = x + dx[dir];
-            const ny = y + dy[dir];
-            if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
-
-            const nIdx = ny * width + nx;
-            if (processed[nIdx]) continue;
-
-            const newDist = d + 1;
-            const newVal = srcEdge * dropOff(newDist, dropOffRate);
-
-            if (newVal > contrastMap[nIdx]) {
-                contrastMap[nIdx] = newVal;
-                queue.push([nIdx, newDist, srcEdge]);
-            }
-        }
-
-        if (processedCount % 10000 === 0) {
-            if (signal.aborted) throw new DOMException("Aborted", "AbortError");
-            onProgress(processedCount / totalPixels);
-            lastYield = await yieldIfNeeded(lastYield);
-        }
-    }
-
-    // Normalize
-    let maxVal = 0;
-    for (const v of contrastMap) {
-        if (v > maxVal) maxVal = v;
-    }
-    if (maxVal > 0) {
-        for (let i = 0; i < contrastMap.length; i++) {
-            contrastMap[i] /= maxVal;
-        }
-    }
-
-    onProgress(1);
-    return contrastMap;
 }
 
 /**

--- a/src/index.html
+++ b/src/index.html
@@ -386,6 +386,17 @@
                         >
                     </a>
                 </li>
+                <li class="group">
+                    <a
+                        href="adaptive-dither/"
+                        class="flex border-stone-200 text-stone-600"
+                    >
+                        adaptive dither
+                        <span class="ml-auto hidden group-hover:inline-block"
+                            >→</span
+                        >
+                    </a>
+                </li>
             </ul>
         </main>
     </body>

--- a/src/photobook/App.tsx
+++ b/src/photobook/App.tsx
@@ -1,8 +1,8 @@
 import { PageEditor } from "@/photobook/PageEditor";
 import { PrintView } from "@/photobook/PrintView";
-import { BookProvider, useBookState } from "@/photobook/useBookState";
 import type { LayoutId } from "@/photobook/types";
 import { LAYOUTS } from "@/photobook/types";
+import { BookProvider, useBookState } from "@/photobook/useBookState";
 import classNames from "classnames";
 import { useState } from "react";
 
@@ -73,9 +73,7 @@ function Editor() {
                     </button>
 
                     {showAddMenu && (
-                        <AddPageMenu
-                            onClose={() => setShowAddMenu(false)}
-                        />
+                        <AddPageMenu onClose={() => setShowAddMenu(false)} />
                     )}
                 </div>
             </main>
@@ -138,12 +136,7 @@ function LayoutThumbnail({ layoutId }: { layoutId: LayoutId }) {
             );
         case "two-photos-vertical":
             return (
-                <div
-                    className={classNames(
-                        base,
-                        "flex flex-col gap-0.5 p-1",
-                    )}
-                >
+                <div className={classNames(base, "flex flex-col gap-0.5 p-1")}>
                     <div className="w-full flex-1 rounded-sm bg-stone-300" />
                     <div className="w-full flex-1 rounded-sm bg-stone-300" />
                 </div>

--- a/src/photobook/PageEditor.tsx
+++ b/src/photobook/PageEditor.tsx
@@ -1,9 +1,9 @@
 import { JournalEditor } from "@/photobook/JournalEditor";
 import { PageRenderer } from "@/photobook/PageRenderer";
 import { PhotoPicker } from "@/photobook/PhotoPicker";
-import { useBookState } from "@/photobook/useBookState";
 import type { LayoutId, Page, PhotoId } from "@/photobook/types";
 import { LAYOUTS } from "@/photobook/types";
+import { useBookState } from "@/photobook/useBookState";
 import classNames from "classnames";
 import { useState } from "react";
 
@@ -93,12 +93,10 @@ export function PageEditor({
 
             {editingSlot?.type === "journal" && (
                 <JournalEditor
-                    initialText={
-                        (() => {
-                            const slot = page.slots[editingSlot.index];
-                            return slot.type === "journal" ? slot.text : "";
-                        })()
-                    }
+                    initialText={(() => {
+                        const slot = page.slots[editingSlot.index];
+                        return slot.type === "journal" ? slot.text : "";
+                    })()}
                     onSave={handleJournalSave}
                     onClose={() => setEditingSlot(null)}
                 />

--- a/src/photobook/PageRenderer.tsx
+++ b/src/photobook/PageRenderer.tsx
@@ -1,5 +1,5 @@
-import { useBookState } from "@/photobook/useBookState";
 import type { LayoutId, Page, PageSlot } from "@/photobook/types";
+import { useBookState } from "@/photobook/useBookState";
 import classNames from "classnames";
 import { ReactNode } from "react";
 

--- a/src/photobook/PhotoPicker.tsx
+++ b/src/photobook/PhotoPicker.tsx
@@ -1,5 +1,5 @@
-import { useBookState } from "@/photobook/useBookState";
 import type { PhotoId } from "@/photobook/types";
+import { useBookState } from "@/photobook/useBookState";
 import classNames from "classnames";
 import { useCallback, useRef } from "react";
 


### PR DESCRIPTION
New toy that processes images with multi-resolution dithering:
- Pass 1: Brightness/contrast preprocessing with scale control
- Pass 2: Sobel edge detection to find high-contrast areas
- Pass 3: Distance-field-like contrast map with configurable drop-off
  functions (linear, exponential, quadratic, sine)
- Pass 4: Adaptive Floyd-Steinberg dithering at multiple block sizes
  (1x1 through 64x64), blending based on contrast map

UI includes side-by-side layout with image preview and control panel,
ability to view each processing pass independently, and sliders for
all parameters.

https://claude.ai/code/session_01R115YGhideSTdnJaDcSYsQ